### PR TITLE
fixed clang errors (again?)

### DIFF
--- a/include/vigra/numpy_array.hxx
+++ b/include/vigra/numpy_array.hxx
@@ -1106,7 +1106,7 @@ void NumpyArray<N, T, Stride>::setupArrayView()
 
         this->m_stride /= sizeof(value_type);
         this->m_ptr = reinterpret_cast<pointer>(pyArray()->data);
-        vigra_precondition(checkInnerStride(Stride()),
+        vigra_precondition(this->checkInnerStride(Stride()),
             "NumpyArray<..., UnstridedArrayTag>::setupArrayView(): First dimension of given array is not unstrided (should never happen).");
 
     }

--- a/vigranumpy/src/core/segmentation.cxx
+++ b/vigranumpy/src/core/segmentation.cxx
@@ -573,7 +573,7 @@ template < class PixelType >
 python::tuple 
 pythonWatersheds2D(NumpyArray<2, Singleband<PixelType> > image,
                    int neighborhood = 4,
-                   NumpyArray<2, Singleband<npy_uint32> > seeds = python::object(),
+                   NumpyArray<2, Singleband<npy_uint32> > seeds = NumpyArray<2, Singleband<npy_uint32> >(),
                    std::string method = "RegionGrowing", 
                    SRGType srgType = CompleteGrow, 
                    PixelType max_cost = 0.0, 
@@ -660,7 +660,7 @@ template < class PixelType >
 python::tuple 
 pythonWatersheds3D(NumpyArray<3, Singleband<PixelType> > image,
                    int neighborhood = 6,
-                   NumpyArray<3, Singleband<npy_uint32> > seeds = python::object(),
+                   NumpyArray<3, Singleband<npy_uint32> > seeds = NumpyArray<3, Singleband<npy_uint32> >(),
                    std::string method = "RegionGrowing", 
                    SRGType srgType = CompleteGrow, 
                    PixelType max_cost = 0.0, 


### PR DESCRIPTION
Some clang-related changes apparently were lost during other merges you recently did in master. 
This version (again) does not give me any clang 2.8 compile errors any more, some warnings however remain (please see CDash dashboard).
