### PR TITLE
Fix in RF matlab interface

### DIFF
--- a/include/vigra/random.hxx
+++ b/include/vigra/random.hxx
@@ -140,12 +140,18 @@ struct RandomState<TT800>
 
     UInt32 get() const
     {
-        if(current_ == N)
-            generateNumbers<void>();
-            
-        UInt32 y = state_[current_++];
-        y ^= (y << 7) & 0x2b5b2500; 
-        y ^= (y << 15) & 0xdb8b0000; 
+		UInt32 y = 0;
+		
+                #pragma omp critical
+		{
+			if(current_ == N)
+				generateNumbers<void>();
+				
+			y = state_[current_++];
+		}
+		
+		y ^= (y << 7) & 0x2b5b2500; 
+		y ^= (y << 15) & 0xdb8b0000; 
         return y ^ (y >> 16);
     }
     

--- a/include/vigra/random_forest.hxx
+++ b/include/vigra/random_forest.hxx
@@ -60,6 +60,10 @@
 #include "random_forest/rf_online_prediction_set.hxx"
 #include "random_forest/rf_earlystopping.hxx"
 #include "random_forest/rf_ridge_split.hxx"
+#ifdef _OPENMP
+    #include <omp.h>
+#endif
+
 namespace vigra
 {
 
@@ -158,7 +162,7 @@ class RandomForest
 
     /** optimisation for predictLabels
      * */
-    mutable MultiArray<2, double> garbage_prediction_;
+    mutable std::vector< MultiArray<2, double> > garbage_prediction_;
 
   public:
 
@@ -588,10 +592,21 @@ class RandomForest
     {
         vigra_precondition(features.shape(0) == labels.shape(0),
             "RandomForest::predictLabels(): Label array has wrong size.");
+	
+        #ifdef _OPENMP
+	    const int numThreads = omp_get_max_threads();
+	    garbage_prediction_.resize( numThreads );
+        #else
+	    garbage_prediction_.resize(1);
+        #endif
 
-        #pragma omp parallel for schedule(dynamic)
-        for(int k=0; k<features.shape(0); ++k)
-            labels(k,0) = detail::RequiresExplicitCast<T>::cast(predictLabel(rowVector(features, k), rf_default()));
+        #pragma omp parallel for schedule(dynamic) num_threads(numThreads)
+        for(int k=0; k<features.shape(0); ++k) {
+            T label = detail::RequiresExplicitCast<T>::cast(predictLabel(rowVector(features, k), rf_default()));
+            
+	    #pragma omp critical
+            labels(k,0) = label;
+	}
     }
 
     template <class U, class C1, class T, class C2, class Stop>
@@ -1016,11 +1031,20 @@ LabelType RandomForest<LabelType, Tag>
         "RandomForestn::predictLabel():"
             " Feature matrix must have a singlerow.");
     typedef MultiArrayShape<2>::type Shp;
+    
+#ifdef _OPENMP
+    const int curThread = omp_get_thread_num();
+    #define garbage_prediction_	garbage_prediction_[curThread]
+#else
+    #define garbage_prediction_ garbage_prediction_[0]
+#endif
+    
     garbage_prediction_.reshape(Shp(1, ext_param_.class_count_), 0.0);
     LabelType          d;
     predictProbabilities(features, garbage_prediction_, stop);
     ext_param_.to_classlabel(argMax(garbage_prediction_), d);
     return d;
+#undef garbage_prediction_
 }
 
 

--- a/include/vigra/random_forest/rf_common.hxx
+++ b/include/vigra/random_forest/rf_common.hxx
@@ -692,7 +692,7 @@ public:
 
     size_t serialized_size() const
     {
-        return 9 + class_count_ *int(is_weighted_+1);
+        return 10 + class_count_ *int(is_weighted_+1);
     }
 
 
@@ -700,7 +700,7 @@ public:
     void unserialize(Iter const & begin, Iter const & end)
     {
         Iter iter = begin;
-        vigra_precondition(end - begin >= 9, 
+        vigra_precondition(end - begin >= 10,
                            "ProblemSpec::unserialize():"
                            "wrong number of parameters");
         #define PULL(item_, type_) item_ = type_(*iter); ++iter;
@@ -719,7 +719,7 @@ public:
         PULL(response_size_, int);
         if(is_weighted_)
         {
-            vigra_precondition(end - begin == 9 + 2*class_count_, 
+            vigra_precondition(end - begin == 10 + 2*class_count_,
                                "ProblemSpec::unserialize(): 2");
             class_weights_.insert(class_weights_.end(),
                                   iter, 

--- a/src/matlab/RandomForestProgressVisitor.hxx
+++ b/src/matlab/RandomForestProgressVisitor.hxx
@@ -14,6 +14,12 @@
   #include <omp.h>
 #endif
 
+struct MatlabRandomForestTreeInfo
+{
+    unsigned int maxDepthLeft;
+    unsigned int maxDepthRight; //depth to right and left of first node
+};
+
 namespace vigra
 {
 namespace rf
@@ -21,16 +27,141 @@ namespace rf
 namespace visitors
 {
 class MatlabRandomForestProgressVisitor : public VisitorBase {
-    private:
+private:
     volatile int numProcessedTrees;
-      
-    public:
-    MatlabRandomForestProgressVisitor() : VisitorBase() { numProcessedTrees = 0; }
+    bool         computeMaxTreeDepth;
+
+    template<class RF>
+    unsigned int maxTreeDepth( RF& rf, int treeIndex, bool leftChild )
+    {
+        typedef vigra::detail::DecisionTree            DecisionTree_t;
+        const DecisionTree_t &tree = rf.trees_[treeIndex];
+
+        typedef typename DecisionTree_t::TreeInt    TreeInt;
+
+        unsigned int maxDepth = 0;
+
+        std::vector<TreeInt> toExplore;
+        std::vector<unsigned int> theDepth;
+
+        int firstChild = 1;
+        if (leftChild)
+            firstChild = 0;
+
+        bool isFirstRound = true;
+
+        toExplore.push_back(2);
+        theDepth.push_back(1);
+
+        while( !toExplore.empty() )
+        {
+            unsigned int thisDepth = theDepth.back();
+            TreeInt index = toExplore.back();
+
+            theDepth.pop_back();
+            toExplore.pop_back();
+
+            // leaf node?
+            if ( (tree.topology_[index] & LeafNodeTag) == LeafNodeTag ) {
+                if (maxDepth < thisDepth)
+                    maxDepth = thisDepth;
+                continue;
+            }
+
+            {
+                switch(tree.topology_[index])
+                {
+                    case i_ThresholdNode:
+                    {
+                        Node<i_ThresholdNode>
+                                    node(tree.topology_, tree.parameters_, index);
+
+                        if (isFirstRound) {
+                            toExplore.push_back(node.child(firstChild));
+                            theDepth.push_back(thisDepth+1);
+                        } else {
+                            toExplore.push_back( node.child(0) );
+                            toExplore.push_back( node.child(1) );
+
+                            theDepth.push_back( thisDepth + 1 );
+                            theDepth.push_back( thisDepth + 1 );
+                        }
+                        break;
+                    }
+                    case i_HyperplaneNode:
+                    {
+                        Node<i_HyperplaneNode>
+                                    node(tree.topology_, tree.parameters_, index);
+                        if (isFirstRound) {
+                            toExplore.push_back(node.child(firstChild));
+                            theDepth.push_back(thisDepth+1);
+                        } else {
+                            toExplore.push_back( node.child(0) );
+                            toExplore.push_back( node.child(1) );
+
+                            theDepth.push_back( thisDepth + 1 );
+                            theDepth.push_back( thisDepth + 1 );
+                        }
+                        break;
+                    }
+                    case i_HypersphereNode:
+                    {
+                        Node<i_HypersphereNode>
+                                    node(tree.topology_, tree.parameters_, index);
+
+                        if (isFirstRound) {
+                            toExplore.push_back(node.child(firstChild));
+                            theDepth.push_back(thisDepth+1);
+                        } else {
+                            toExplore.push_back( node.child(0) );
+                            toExplore.push_back( node.child(1) );
+
+                            theDepth.push_back( thisDepth + 1 );
+                            theDepth.push_back( thisDepth + 1 );
+                        }
+
+                        break;
+                    }
+                #if 0
+                        // for quick prototyping! has to be implemented.
+                        case i_VirtualNode:
+                        {
+                            Node<i_VirtualNode>
+                                        node(topology_, parameters, index);
+                            index = node.next(features);
+                        }
+                #endif
+                    default:
+                        vigra_fail("DecisionTree::getToLeaf():"
+                                   "encountered unknown internal Node Type");
+                }
+            }
+
+            isFirstRound = false;
+        }
+
+        return maxDepth;
+    }
+
+public:
+    void setComputeMaxTreeDepth(bool yes) { computeMaxTreeDepth = yes; }
+    MatlabRandomForestProgressVisitor() : VisitorBase() { numProcessedTrees = 0; computeMaxTreeDepth = false; }
+    std::vector<MatlabRandomForestTreeInfo>  treeInfo;
 
     template<class RF, class PR, class SM, class ST>
-    void visit_after_tree(RF& rf, PR & pr,  SM & sm, ST & st, int index){
+    void visit_after_tree(RF& rf, PR & pr,  SM & sm, ST & st, int treeIndex){
         #pragma omp critical
-        numProcessedTrees++;
+        {
+            if (treeInfo.size() != rf.options().tree_count_)
+                treeInfo.resize( rf.options().tree_count_ );
+
+            if (computeMaxTreeDepth)
+            {
+                treeInfo.at(numProcessedTrees).maxDepthLeft = maxTreeDepth( rf, treeIndex, true );
+                treeInfo.at(numProcessedTrees).maxDepthRight = maxTreeDepth( rf, treeIndex, false );
+            }
+            numProcessedTrees++;
+        }
 	
 	int totalTrees = rf.options().tree_count_;
 	

--- a/src/matlab/RandomForestProgressVisitor.hxx
+++ b/src/matlab/RandomForestProgressVisitor.hxx
@@ -35,9 +35,13 @@ class MatlabRandomForestProgressVisitor : public VisitorBase {
 	int totalTrees = rf.options().tree_count_;
 	
 #ifdef _OPENMP
-	if (omp_get_thread_num() == 0)	// main thread?
+        if (omp_get_thread_num() == 0) {	// main thread?
 #endif
         mexPrintf("%d of %d learned (%.1f%%)\n", numProcessedTrees, totalTrees, numProcessedTrees * 100.0 / totalTrees); 
+#ifdef _OPENMP
+        mexEvalString("drawnow");
+      }
+#endif
     }
     
     template<class RF, class PR>

--- a/src/matlab/random_forest_impex.hxx
+++ b/src/matlab/random_forest_impex.hxx
@@ -49,7 +49,7 @@ template<class T>
 void importRandomForest(vigra::RandomForest<T> &rf,ConstCellArray cells)
 {
     // read RF parameters
-    MultiArrayView<1, UInt32> e_param = getArray<UInt32>(cells[0]);
+    MultiArrayView<1, double> e_param = getArray<double>(cells[0]);
     rf.ext_param_.unserialize(e_param.data(), e_param.data()+ e_param.size());
 
     MultiArrayView<1, UInt32> opt = getArray<UInt32>(cells[1]);
@@ -81,7 +81,7 @@ exportRandomForest(RandomForest<T> const & rf, CellArray cells)
 {
     // write RF parameters
     int parameterCount = rf.ext_param_.serialized_size();
-    MultiArrayView<1, UInt32> parameters = createArray<UInt32>(parameterCount, cells[0]);
+    MultiArrayView<1, double> parameters = createArray<double>(parameterCount, cells[0]);
     rf.ext_param_.serialize(parameters.data(), parameters.data()+parameterCount);
 
 

--- a/src/matlab/vigraPredictProbabilitiesRF.cpp
+++ b/src/matlab/vigraPredictProbabilitiesRF.cpp
@@ -46,12 +46,15 @@ using namespace visitors;
 
 void vigraMain(matlab::OutputArray outputs, matlab::InputArray inputs){
     /* INPUT */
-    if (inputs.size() != 2)
-        mexErrMsgTxt("Two inputs required.");
+    if (inputs.size() < 2)
+        mexErrMsgTxt("At least two inputs required.");
 
     // get RF object
     RandomForest<> rf; 
     matlab::importRandomForest(rf, matlab::getCellArray(inputs[0]));
+    
+    rf.options_.predict_weighted_ = inputs.getBool("weight_with_number_of_samples", v_default(false));
+    mexPrintf("Predict weighted: %d\n", (int) rf.options_.predict_weighted_);
 
     // get feature matrix
     MultiArrayView<2, double> features = inputs.getMultiArray<2, double> ( 1, v_required());


### PR DESCRIPTION
I have noticed that there is a hardcoded value that seems to be incorrectly computed. Because of this, the RF model saved to matlab is incorrect and has a missing value. This commit fixes this, which is a bug that would also apply to any other code calling the serialize() function of the RF options.

I have also changed the MATLAB structure type of the RF options to double, since class labels as well as class weights are typically double, plus the fact that serialze() is using std::copy, so the same type (double) is needed for this to be meaningful.

Maybe this means that the RF matlab interface + options serialization needs to be double-checked.