### PR TITLE
 RandomForest: When importing from Hdf5, open file in read-only mode.

### DIFF
--- a/include/vigra/random_forest_hdf5_impex.hxx
+++ b/include/vigra/random_forest_hdf5_impex.hxx
@@ -296,7 +296,7 @@ bool rf_import_HDF5(RandomForest<T, Tag> & rf,
                     const std::string & filename, 
                     const std::string & pathname = "")
 {
-    HDF5File h5context(filename, HDF5File::Open);
+    HDF5File h5context(filename, HDF5File::OpenReadOnly);
     return rf_import_HDF5(rf, h5context, pathname);
 }
 


### PR DESCRIPTION
This commit avoids errors when importing RandomForest from read-only files:

RuntimeError: HDF5File.open(): Could not open or create file '/Users/bergs/SomeForest.h5'
