### PR TITLE
export TinyVector with short type, too

### DIFF
--- a/vigranumpy/src/core/converters.cxx
+++ b/vigranumpy/src/core/converters.cxx
@@ -323,6 +323,7 @@ void registerNumpyShapeConvertersAllTypes()
     registerNumpyShapeConvertersOneType<MultiArrayIndex>();
     registerNumpyShapeConvertersOneType<float>();
     registerNumpyShapeConvertersOneType<double>();
+    registerNumpyShapeConvertersOneType<short>();
     if(typeid(npy_intp) != typeid(MultiArrayIndex))
         MultiArrayShapeConverter<0, npy_intp>();
 }


### PR DESCRIPTION
I'd like to be able to convert tuples of numbers into TinyVector's with shorts
