### PR TITLE
Disable VIGRANumPy by default with GNU c++ < 4.4 on MacOSX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,18 @@ IF (MSVC)
     ADD_DEFINITIONS(-D_CRT_SECURE_NO_DEPRECATE -D_SCL_SECURE_NO_DEPRECATE)
 ENDIF ()
 
+IF (CMAKE_COMPILER_IS_GNUCXX AND ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    EXEC_PROGRAM(
+        ${CMAKE_CXX_COMPILER}
+        ARGS                    --version
+        OUTPUT_VARIABLE _compiler_output)
+    STRING(REGEX REPLACE ".*([0-9]\\.[0-9]\\.[0-9]).*" "\\1"  gcc_compiler_version ${_compiler_output})
+    IF (gcc_compiler_version VERSION_LESS "4.4.0")
+        MESSAGE(WARNING "GNU c++ < 4.4 cannot build VIGRANumPy; disabling (found GCC ${gcc_compiler_version})")
+        SET(WITH_VIGRANUMPY 0)
+    ENDIF ()
+ENDIF ()
+
 # if(CMAKE_COMPILER_IS_GNUCXX)
   # exec_program(
       # ${CMAKE_CXX_COMPILER}


### PR DESCRIPTION
This developer's machine is basically stuck with GNU C++ 4.2 as that is
the last XCode version available for MacOSX 10.6 (and the machine is not
upgradeable).

Rather than leaving other developers with the same problem puzzled about a
weird and long compile error, let's be nice and just disable VIGRANumPy in
that case.

Signed-off-by: Johannes Schindelin johannes.schindelin@gmx.de
