### PR TITLE
test/multiarray/CMakeLists.txt: On Mac, use -stdlib=libc++

### DIFF
--- a/test/multiarray/CMakeLists.txt
+++ b/test/multiarray/CMakeLists.txt
@@ -18,4 +18,8 @@ if(NOT MSVC)
     SET(CMAKE_CXX_FLAGS "-pthread -std=c++11 ${CMAKE_CXX_FLAGS}")
 endif()
 
+if(APPLE)
+    SET(CMAKE_CXX_FLAGS "-stdlib=libc++ ${CMAKE_CXX_FLAGS}")
+endif()
+
 VIGRA_ADD_TEST(test_multiarray_chunked test_chunked.cxx)


### PR DESCRIPTION
This adds `-stdlib=libc++` to the compiler flags when building on Mac.  (It should not be used on Linux, since those systems typically use the GNU implementation of the std c++ library implementation, a.k.a. libstdc++, not libc++)
