### PR TITLE
Add the -std=c++0x flag to the CXX compile options such that it finds std::shared_ptr etc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,8 @@ IF (MSVC)
 ENDIF ()
 
 IF (CMAKE_COMPILER_IS_GNUCXX)
-    # ADD_DEFINITIONS(-std=c++0x)  # will be needed to enable native thread support
+    # needed to enable native thread support and to supply std::shared_ptr etc outside of tr1
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
     
     IF (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
         # As of cmake 2.8.10, there is a variable CMAKE_CXX_COMPILER_VERSION.


### PR DESCRIPTION
Why was the line `ADD_DEFINITIONS(-std=c++0x)` commented out before? 

At least GCC 4.8 needs it, and it should not hurt for prior GCC versions (GCC 4.7 builds fine with the flag set). Those that would not know this flag are too old to compile vigra anyway.

Replaced it with `SET(CMAKE_CXX_FLAGS -std=c++0x)` to only add it to CXX and not CC to prevent warnings from the C compiler.

Tested with GCC 4.8 on OSX 10.9 Mavericks, and GCC 4.7 on Debian.