### PR TITLE
Added parts of my developments to the vigra Computer Vision library...

### DIFF
--- a/include/vigra/medianfilter.hxx
+++ b/include/vigra/medianfilter.hxx
@@ -121,7 +121,8 @@ public:
         SrcIterator ys = s_ul;
         SrcIterator xs = ys;
         
-        typename std::vector<VALUETYPE>::iterator iter = m_buffer.begin();
+        typename std::vector<VALUETYPE>::iterator iter = m_buffer.begin(),
+                                                  median_iter = m_buffer.begin()+m_buffer.size()/2;
         
         for( ; ys.y != s_lr.y; ys.y++)
         {   
@@ -131,8 +132,8 @@ public:
             }       
         }
         
-        std::sort(m_buffer.begin(), m_buffer.end());
-        d_acc.set(m_buffer[m_buffer.size()/2],d);
+        std::nth_element(m_buffer.begin(), median_iter, m_buffer.end());
+        d_acc.set(*median_iter,d);
     }
     
     Diff2D windowShape() const

--- a/test/correlation/test.cxx
+++ b/test/correlation/test.cxx
@@ -90,6 +90,7 @@ struct FastVsSlowCorrelationTest
             fastNormalizedCrossCorrelation(img,
                                            img.subarray(Shape2(0,0),Shape2(mask_size,mask_size)),
                                            result_fast);
+            
             result_slow=0;
             normalizedCrossCorrelation(img,
                                        img.subarray(Shape2(0,0),Shape2(mask_size,mask_size)),


### PR DESCRIPTION
Finally I managed to integrate the first few things, which I developed for my PhD thesis:
1. A local (window based) filter function environment. 
   applywindowfunction.hxx, medianfilter.hxx, specklefilters.hxx
   It can be used to apply any given filter function on a complete image. Like convolveImage, this environment also supports correct border handling at the image boundaries. To demonstrate the use, I added a generic median filter and some of the most commonly used filters for speckle removal as well. 
2. A Coherence Enhancing Shock Filter
   shockfilter.hxx
   This one was proposed by J. Weickert 2002 in "Coherence-Enhancing Shock Filters". It uses the Structure Tensor, a map and a weighted erosions/dilation function which perfoms "discrete upwinding" according to signums of the computed map. The results are images, that look like from Munch or van Gogh.
3. A correlation environment
   correlation.hxx
   This one provides traditional correlation approaches using sliding windows as well as FFT powered fast versions of the cross-correlation as well as the normalized cross-correlation according to J.P. Lewis 1995: "Fast normalized cross correlation".

All of the included components are tested - tests are supplied by means of vigra tests (test/filters and test/correlation). And they are all documented by means of doxygen comments. All callable algorithms provide the new MultiArrayView calling mechanisms as well as the good old image iterators.
