### PR TITLE
fix LaTeX error

### DIFF
--- a/include/vigra/accumulator.hxx
+++ b/include/vigra/accumulator.hxx
@@ -6075,7 +6075,7 @@ class RegionPerimeter
 /** \brief Compute the circularity of a 2D region. 
 
     The is the ratio between the perimeter of a circle with the same area as the 
-    present region and the perimeter of the region, i.e. \f[c = \frac{2 \sqrt{\pi a}{p} \f], where a and p are the area and length of the polygon returned by RegionContour.
+    present region and the perimeter of the region, i.e. \f[c = \frac{2 \sqrt{\pi a}}{p} \f], where a and p are the area and length of the polygon returned by RegionContour.
     
     AccumulatorChain must be used with CoupledIterator in order to have access to pixel coordinates.
  */


### PR DESCRIPTION
This fixes the Doxygen build w/ LaTeX, and makes the documentation match the code.  However, I wonder whether the pi should be in the denominator instead (but also in the code)?
AFAICS, the perimeter of an area-equivalent circle would be 2_sqrt(A/pi), not (A_pi).
