### PR TITLE
Fix an off-by-one error in function exportImageAlpha.

### DIFF
--- a/include/vigra/impexalpha.hxx
+++ b/include/vigra/impexalpha.hxx
@@ -789,7 +789,7 @@ namespace vigra
 
             encoder->setPixelType(pixel_type);
 
-            vigra_precondition(isBandNumberSupported(encoder->getFileType(), image_accessor.size(image_upper_left)),
+            vigra_precondition(isBandNumberSupported(encoder->getFileType(), image_accessor.size(image_upper_left) + 1U),
                                "exportImageAlpha(): file format does not support requested number of bands (color channels)");
 
             const range_t image_source_range(find_source_value_range(export_info,


### PR DESCRIPTION
A co-developer in the Enblend/Enfuse project discovered that he cannot export OpenEXR
images with an alpha channel, because a `vigra_precondition` is wrong.  The problem does
not show up with image formats that support three and four channels, which is the reason
why the bug has gone unnoticed for so long.
