### PR TITLE
python support for labelMultiArray()

### DIFF
--- a/vigranumpy/src/core/segmentation.cxx
+++ b/vigranumpy/src/core/segmentation.cxx
@@ -217,6 +217,81 @@ pythonLabelVolumeWithBackground(NumpyArray<3, Singleband<VoxelType> > volume,
 
 VIGRA_PYTHON_MULTITYPE_FUNCTOR(pyLabelVolumeWithBackground, pythonLabelVolumeWithBackground)
 
+template < class VoxelType, unsigned int ndim >
+NumpyAnyArray
+pythonLabelMultiArray(NumpyArray<ndim, Singleband<VoxelType> > volume,
+                      std::string neighborhood="",
+                      NumpyArray<ndim, Singleband<npy_uint32> > res = NumpyArray<ndim, Singleband<npy_uint32> >())
+{
+    neighborhood = tolower(neighborhood);
+    if (neighborhood == "")
+    {
+        neighborhood = "direct";
+    }
+
+    vigra_precondition(neighborhood == "direct" || neighborhood == "indirect",
+        "labelMultiArray(): neighborhood must be 'direct' or 'indirect'.");
+
+    std::string description("connected components with background, neighborhood=" + neighborhood);
+
+    res.reshapeIfEmpty(volume.taggedShape().setChannelDescription(description),
+        "labelMultiArray(): Output array has wrong shape.");
+
+    {
+        PyAllowThreads _pythread;
+        if (neighborhood == "direct")
+        {
+            labelMultiArray(volume, res, DirectNeighborhood);
+        }
+        else
+        {
+            labelMultiArray(volume, res, IndirectNeighborhood);
+        }
+    }
+    return res;
+}
+
+
+template < class VoxelType, unsigned int ndim >
+NumpyAnyArray
+pythonLabelMultiArrayWithBackground(NumpyArray<ndim, Singleband<VoxelType> > volume,
+                                std::string neighborhood="",
+                                VoxelType background_value = 0,
+                                NumpyArray<ndim, Singleband<npy_uint32> > res = NumpyArray<ndim, Singleband<npy_uint32> >())
+{
+    neighborhood = tolower(neighborhood);
+    if (neighborhood == "")
+    {
+        neighborhood = "direct";
+    }
+    vigra_precondition(neighborhood == "direct" || neighborhood == "indirect",
+        "labelMultiArrayWithBackground(): neighborhood must be 'direct' or 'indirect'.");
+
+    std::string description("connected components with background, neighborhood=");
+    description += neighborhood + ", bglabel=" + asString(background_value);
+
+    res.reshapeIfEmpty(volume.taggedShape().setChannelDescription(description),
+        "labelMultiArrayWithBackground(): Output array has wrong shape.");
+
+    {
+        PyAllowThreads _pythread;
+        if (neighborhood == "direct")
+        {
+            labelMultiArrayWithBackground(volume,
+                res, DirectNeighborhood,
+                background_value);
+        }
+        else
+        {
+            labelMultiArrayWithBackground(volume,
+                res, IndirectNeighborhood,
+                background_value);
+        }
+    }
+    return res;
+}
+
+
 /*********************************************************************************/
 
 // FIXME: support output of label images from localMinim/Maxima functions
@@ -1081,7 +1156,118 @@ void defineSegmentation()
         "the pixel neighborhood to be used and can be 6 (default) or 26.\n"
         "\n"
         "For details see labelVolumeWithBackground_ in the vigra C++ documentation.\n");
-    
+
+    def("labelMultiArray",
+        registerConverters(&pythonLabelMultiArray<npy_uint8, 2>),
+        (arg("volume"), arg("neighborhood")="", arg("out")=python::object()),
+        "Find the connected components of a segmented ND array."
+        "Parameter 'neighborhood' specifies the pixel neighborhood "
+        "to be used and can be 'direct' (default) or 'indirect'.\n"
+        "\n"
+        "For details see labelMultiArray_ in the vigra C++ documentation.\n");
+
+    def("labelMultiArray",
+        registerConverters(&pythonLabelMultiArray<npy_uint8, 2>),
+        (arg("volume"), arg("neighborhood")="", arg("out")=python::object()), "");
+
+    def("labelMultiArray",
+        registerConverters(&pythonLabelMultiArray<npy_uint8, 3>),
+        (arg("volume"), arg("neighborhood")="", arg("out")=python::object()), "");
+
+    def("labelMultiArray",
+        registerConverters(&pythonLabelMultiArray<npy_uint8, 4>),
+        (arg("volume"), arg("neighborhood")="", arg("out")=python::object()), "");
+
+    def("labelMultiArray",
+        registerConverters(&pythonLabelMultiArray<npy_uint8, 5>),
+        (arg("volume"), arg("neighborhood")="", arg("out")=python::object()), "");
+
+    def("labelMultiArray",
+        registerConverters(&pythonLabelMultiArray<npy_uint32, 2>),
+        (arg("volume"), arg("neighborhood")="", arg("out")=python::object()), "");
+
+    def("labelMultiArray",
+        registerConverters(&pythonLabelMultiArray<npy_uint32, 3>),
+        (arg("volume"), arg("neighborhood")="", arg("out")=python::object()), "");
+
+    def("labelMultiArray",
+        registerConverters(&pythonLabelMultiArray<npy_uint32, 4>),
+        (arg("volume"), arg("neighborhood")="", arg("out")=python::object()), "");
+
+    def("labelMultiArray",
+        registerConverters(&pythonLabelMultiArray<npy_uint32, 5>),
+        (arg("volume"), arg("neighborhood")="", arg("out")=python::object()), "");
+
+    def("labelMultiArray",
+        registerConverters(&pythonLabelMultiArray<float, 2>),
+        (arg("volume"), arg("neighborhood")="", arg("out")=python::object()), "");
+
+    def("labelMultiArray",
+        registerConverters(&pythonLabelMultiArray<float, 3>),
+        (arg("volume"), arg("neighborhood")="", arg("out")=python::object()), "");
+
+    def("labelMultiArray",
+        registerConverters(&pythonLabelMultiArray<float, 4>),
+        (arg("volume"), arg("neighborhood")="", arg("out")=python::object()), "");
+
+    def("labelMultiArray",
+        registerConverters(&pythonLabelMultiArray<float, 5>),
+        (arg("volume"), arg("neighborhood")="", arg("out")=python::object()), "");
+
+    def("labelMultiArrayWithBackground",
+        registerConverters(&pythonLabelMultiArrayWithBackground<npy_uint8, 2>),
+        (arg("volume"), arg("neighborhood")="", arg("background_value")=0, arg("out")=python::object()),
+        "Find the connected components of a segmented ND array, excluding the "
+        "background from labeling, where the background is the set of all pixels with "
+        "the given 'background_value'. Parameter 'neighborhood' specifies "
+        "the pixel neighborhood to be used and can be 'direct' (default) or 'indirect'.\n"
+        "\n"
+        "For details see labelMultiArrayWithBackground_ in the vigra C++ documentation.\n");
+
+    def("labelMultiArrayWithBackground",
+        registerConverters(&pythonLabelMultiArrayWithBackground<npy_uint8, 3>),
+        (arg("volume"), arg("neighborhood")="", arg("background_value")=0, arg("out")=python::object()), "");
+
+    def("labelMultiArrayWithBackground",
+        registerConverters(&pythonLabelMultiArrayWithBackground<npy_uint8, 4>),
+        (arg("volume"), arg("neighborhood")="", arg("background_value")=0, arg("out")=python::object()), "");
+
+    def("labelMultiArrayWithBackground",
+        registerConverters(&pythonLabelMultiArrayWithBackground<npy_uint8, 5>),
+        (arg("volume"), arg("neighborhood")="", arg("background_value")=0, arg("out")=python::object()), "");
+
+    def("labelMultiArrayWithBackground",
+        registerConverters(&pythonLabelMultiArrayWithBackground<npy_uint32, 2>),
+        (arg("volume"), arg("neighborhood")="", arg("background_value")=0, arg("out")=python::object()), "");
+
+    def("labelMultiArrayWithBackground",
+        registerConverters(&pythonLabelMultiArrayWithBackground<npy_uint32, 3>),
+        (arg("volume"), arg("neighborhood")="", arg("background_value")=0, arg("out")=python::object()), "");
+
+    def("labelMultiArrayWithBackground",
+        registerConverters(&pythonLabelMultiArrayWithBackground<npy_uint32, 4>),
+        (arg("volume"), arg("neighborhood")="", arg("background_value")=0, arg("out")=python::object()), "");
+
+    def("labelMultiArrayWithBackground",
+        registerConverters(&pythonLabelMultiArrayWithBackground<npy_uint32, 5>),
+        (arg("volume"), arg("neighborhood")="", arg("background_value")=0, arg("out")=python::object()), "");
+
+    def("labelMultiArrayWithBackground",
+        registerConverters(&pythonLabelMultiArrayWithBackground<float, 2>),
+        (arg("volume"), arg("neighborhood")="", arg("background_value")=0, arg("out")=python::object()), "");
+
+    def("labelMultiArrayWithBackground",
+        registerConverters(&pythonLabelMultiArrayWithBackground<float, 3>),
+        (arg("volume"), arg("neighborhood")="", arg("background_value")=0, arg("out")=python::object()), "");
+
+    def("labelMultiArrayWithBackground",
+        registerConverters(&pythonLabelMultiArrayWithBackground<float, 4>),
+        (arg("volume"), arg("neighborhood")="", arg("background_value")=0, arg("out")=python::object()), "");
+
+    def("labelMultiArrayWithBackground",
+        registerConverters(&pythonLabelMultiArrayWithBackground<float, 5>),
+        (arg("volume"), arg("neighborhood")="", arg("background_value")=0, arg("out")=python::object()), "");
+
     /******************************************************************************/
     
     def("localMinima",

--- a/vigranumpy/test/CMakeLists.txt
+++ b/vigranumpy/test/CMakeLists.txt
@@ -8,6 +8,7 @@ SET(TEST_SCRIPTS
     test3.py
     test4.py
     test_color.py
+    test_segmentation.py
     )
 
 # setup the file 'testsuccess.cxx' which will become out-of-date when the

--- a/vigranumpy/test/test_segmentation.py
+++ b/vigranumpy/test/test_segmentation.py
@@ -1,0 +1,37 @@
+import sys
+print >> sys.stderr, "\nexecuting test file", __file__
+execfile('set_paths.py')
+
+import numpy
+import vigra
+
+def _impl_test_labelMultiArray(dtype):
+    a = numpy.zeros( (10,10,10,10,2), dtype=dtype )
+    a[3:4, 5:8, 5:8, 5:8] = 100
+    a[4:5, 8:10, 5:8, 5:8] = 100 # touches above object on corners only.
+    
+    a[3:4, 1:4, 5:8, 5:8] = 200
+    
+    labeled = vigra.analysis.labelMultiArray(a)
+    assert labeled.dtype == numpy.uint32
+    assert labeled.max() == 4
+
+    labeled = vigra.analysis.labelMultiArrayWithBackground(a)
+    assert labeled.dtype == numpy.uint32
+    assert labeled.max() == 3
+
+    labeled = vigra.analysis.labelMultiArrayWithBackground(a, neighborhood='indirect')
+    assert labeled.dtype == numpy.uint32
+    assert labeled.max() == 2
+    
+    labeled = vigra.analysis.labelMultiArrayWithBackground(a, background_value=100)
+    assert labeled.dtype == numpy.uint32
+    assert labeled.max() == 2
+
+def test_labelMultiArray():
+    _impl_test_labelMultiArray(numpy.uint8)
+    _impl_test_labelMultiArray(numpy.uint32)
+    _impl_test_labelMultiArray(numpy.float32)
+    
+def ok_():
+    print >> sys.stderr, ".",


### PR DESCRIPTION
This PR adds wrappers for `labelMultiArray()` and `labelMultiArrayWithBackground()` for arrays of up to 5D in `vigranumpy/src/core/segmentation.cxx`.

I wasn't sure how to leverage vigranumpy's `multidef` function to wrap a function with support for several types _and_ several dimensionalities; hence the explosion of `def`s.  If there's a smarter way to do this, let me know.
