### PR TITLE
Fix cppcheck reports:

### DIFF
--- a/src/impex/bmp.cxx
+++ b/src/impex/bmp.cxx
@@ -792,7 +792,7 @@ void BmpDecoderImpl::read_rgb_data ()
 
 void BmpDecoder::init( const std::string & filename )
 {
-    pimpl = new BmpDecoderImpl( filename.c_str() );
+    pimpl = new BmpDecoderImpl( filename );
 }
 
 BmpDecoder::~BmpDecoder()

--- a/src/impex/pnm.cxx
+++ b/src/impex/pnm.cxx
@@ -402,7 +402,7 @@ namespace vigra {
 
     void PnmDecoder::init( const std::string & filename )
     {
-        pimpl = new PnmDecoderImpl( filename.c_str() );
+        pimpl = new PnmDecoderImpl( filename );
     }
 
     PnmDecoder::~PnmDecoder()


### PR DESCRIPTION
[src/impex/bmp.cxx:795]: (performance) Passing the result of c_str() to a function that takes std::string as argument no. 1 is slow and redundant.
[src/impex/pnm.cxx:405]: (performance) Passing the result of c_str() to a function that takes std::string as argument no. 1 is slow and redundant.