### PR TITLE
remove outdated documentation link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,11 @@ or online at
 Documentation
 -------------
 
-If you downloaded an official release, the documentation can be found in $VIGRA_PATH/doc/vigra/, the start file 
-is $VIGRA_PATH/doc/vigra/index.html. Online documentation for the latest release is at 
-http://hci.iwr.uni-heidelberg.de/vigra/doc/vigra/index.html
+If you downloaded an official release, the documentation can be found in `$VIGRA_PATH/doc/vigra/`, the start file 
+is `$VIGRA_PATH/doc/vigra/index.html`.
 
 When you use the development version from github, you can generate documentation by `make doc`. Up-to-date 
-online documentation for the 'master' branch is at http://ukoethe.github.io/vigra/doc/vigra/index.html
+online documentation for the 'master' branch is regularly pushed to http://ukoethe.github.io/vigra/doc/vigra/
 
 Download
 --------


### PR DESCRIPTION
The HCI URL redirects to the github.io one, but the README mentions both
as documenting different versions.

*Note:* The "GridGraph" parts of the online documentation are currently broken / missing (404s).

(Also, beautify the URLs by omitting /index.html.)
