### PR TITLE
MultiArrayView.stridearray(): Fix off-by-one error.

### DIFF
--- a/include/vigra/multi_array.hxx
+++ b/include/vigra/multi_array.hxx
@@ -1453,7 +1453,7 @@ public:
     {
         difference_type shape = m_shape;
         for (unsigned int i = 0; i < actual_dimension; ++i)
-            shape [i] /= s [i];
+            shape[i] = (shape[i] + s[i] - 1) / s[i];
         return MultiArrayView <N, T, StridedArrayTag>(shape, m_stride * s, m_ptr);
     }
 

--- a/test/multiarray/test.cxx
+++ b/test/multiarray/test.cxx
@@ -1436,9 +1436,9 @@ public:
         
         strided_array_t st = a3.stridearray (shape3_t(3,4,6));
 
-        shouldEqual (st.shape (0), 6);
-        shouldEqual (st.shape (1), 7);
-        shouldEqual (st.shape (2), 8);
+        shouldEqual (st.shape (0), 7);
+        shouldEqual (st.shape (1), 8);
+        shouldEqual (st.shape (2), 9);
         
         // test hierarchical navigation
         typedef strided_array_t::traverser Traverser3;
@@ -1465,9 +1465,9 @@ public:
             ++countz;
         }
 
-        shouldEqual (countx, 336u);
-        shouldEqual (county, 56u);
-        shouldEqual (countz, 8u);
+        shouldEqual (countx, 504u);
+        shouldEqual (county, 72u);
+        shouldEqual (countz, 9u);
   
         // test direct navigation
         strided_array_t::traverser i = st.traverser_begin();        


### PR DESCRIPTION
In numpy:
```
In [1]: np.zeros((20,30,50))[::3, ::4, ::6].shape
Out[1]: (7, 8, 9)
```

But in vigra, the off-by-one error yielded shape: (6,7,8)