### PR TITLE
impex: fix PNG setPosition when some coordinates are zero or negative

### DIFF
--- a/include/vigra/imageinfo.hxx
+++ b/include/vigra/imageinfo.hxx
@@ -322,10 +322,11 @@ class ImageExportInfo
 
             Currently only supported by TIFF, PNG and OpenEXR files.
 
-            The offset is encoded in the XPosition and YPosition TIFF tags.
+            The offset is encoded in the XPosition and YPosition TIFF tags. TIFF
+            requires that the resolution must also be set.
 
             @param pos     position of the upper left corner in pixels
-                           (must be >= 0)
+                           (must be >= 0 for TIFF)
          **/
     VIGRA_EXPORT ImageExportInfo & setPosition(const Diff2D & pos);
 

--- a/src/impex/png.cxx
+++ b/src/impex/png.cxx
@@ -587,7 +587,7 @@ namespace vigra {
         }
 
         // set offset
-        if (position.x > 0 && position.y > 0) {
+        if (position.x != 0 || position.y != 0) {
             if (setjmp(png_jmpbuf(png)))
                 vigra_postcondition( false, png_error_message.insert(0, "error in png_set_oFFs(): ").c_str() );
             png_set_oFFs(png, info, position.x, position.y, PNG_OFFSET_PIXEL);

--- a/test/impex/test.cxx
+++ b/test/impex/test.cxx
@@ -676,6 +676,58 @@ class CanvasSizeTest
     }
 };
 
+class PositionTest
+{
+  public:
+    void testFile(const char* filename)
+    {
+        ImageExportInfo exportinfo(filename);
+        FRGBImage img(1, 1);
+        img(0, 0) = 1;
+
+        const Diff2D position(0, 100);
+        exportinfo.setPosition(position);
+        exportinfo.setXResolution(1.0);
+        exportinfo.setYResolution(1.0);
+
+        exportImage(srcImageRange(img), exportinfo);
+
+        ImageImportInfo info(filename);
+
+        should (info.getPosition() == position);
+    }
+
+    void testEXRPosition()
+    {
+#if !defined(HasEXR)
+        FRGBImage img(1, 1);
+        failCodec(img, vigra::ImageExportInfo("res.exr"));
+#else
+        testFile("res.exr");
+#endif
+    }
+
+    void testTIFFPosition()
+    {
+#if !defined(HasTIFF)
+        FRGBImage img(1, 1);
+        failCodec(img, vigra::ImageExportInfo("res.tif"));
+#else
+        testFile("res.tif");
+#endif
+    }
+
+    void testPNGPosition()
+    {
+#if !defined(HasPNG)
+        FRGBImage img(1, 1);
+        failCodec(img, vigra::ImageExportInfo("res.png"));
+#else
+        testFile("res.png");
+#endif
+    }
+};
+
 class PNGInt16Test
 {
   public:
@@ -1802,6 +1854,10 @@ struct ImageImportExportTestSuite : public vigra::test_suite
 #endif
 
         add(testCase(&CanvasSizeTest::testTIFFCanvasSize));
+
+        add(testCase(&PositionTest::testEXRPosition));
+        add(testCase(&PositionTest::testTIFFPosition));
+        add(testCase(&PositionTest::testPNGPosition));
 
         // grayscale float images
         add(testCase(&FloatImageExportImportTest::testGIF));


### PR DESCRIPTION
When exporting PNGs, `PngEncoderImpl` would not set position offset unless both the x and y offset passed to `setPosition` were positive. According to the PNG `oFFs` chunk specification, any signed integer value is permissible. Instead, set the offset whenever either position coordinate is non-zero.

Update `setPosition` documentation to reflect that only TIFF requires non-negative position values and also requires resolution to be set.

Includes test cases covering all file types supporting `setPosition` (OpenEXR, PNG, and TIFF).

This is my first PR to Vigra so let me know if there are any contribution/coding guidelines I should follow (nothing turned up on a cursory search through the website).