### PR TITLE
Fix name conflict when compiling with -DWITH_BOOST_THREAD

### DIFF
--- a/include/vigra/graphs.hxx
+++ b/include/vigra/graphs.hxx
@@ -45,6 +45,12 @@
 #include "metaprogramming.hxx"
 #include "tinyvector.hxx"
 
+#ifdef USE_BOOST_THREAD
+// If boost is available, go ahead and include its tuple implementation
+// to avoid naming conflicts with our own definition of tie(), below.
+#include <boost/tuple/tuple.hpp>
+#endif
+
 #ifdef WITH_BOOST_GRAPH
 
 #  include <boost/tuple/tuple.hpp>


### PR DESCRIPTION
If boost is going to be included eventually, avoid defining our own implementation of `boost::tie()`.
Without this patch, compilation is sensitive to order of `#include` directives (and `test_watersheds` fails to build on my machine).
