### PR TITLE
Use Travis CI's version of the Python library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ before_script:
    
 script:
   - mkdir build && cd build
-  - cmake -DCMAKE_BUILD_TYPE=Release -DDEPENDENCY_SEARCH_PREFIX=$VIRTUAL_ENV -DAUTOBUILD_TESTS=1 -DAUTOEXEC_TESTS=0 -DVIGRANUMPY_LIBRARIES="/usr/lib/libpython2.7.so;/usr/lib/libboost_python.so" ..
+  - cmake -DCMAKE_BUILD_TYPE=Release -DDEPENDENCY_SEARCH_PREFIX=$VIRTUAL_ENV -DAUTOBUILD_TESTS=1 -DAUTOEXEC_TESTS=0 -DVIGRANUMPY_LIBRARIES="/opt/python/${TRAVIS_PYTHON_VERSION}*/lib/libpython${TRAVIS_PYTHON_VERSION}.so;/usr/lib/libboost_python.so" ..
   - make
   - make test


### PR DESCRIPTION
Travis CI installs Python under the `/opt` directory instead. This looks for `libpython` in that directory. Additionally, Travis CI sets the environment variable `$TRAVIS_PYTHON_VERSION`. We can leverage this value to get at the Python library. This will be useful when using build matrices to test compatibility on other versions of Python (e.g. 3.x).