### PR TITLE
cmake: Added VIGRA_IMPEX_EXTRA_C_FLAGS variable

### DIFF
--- a/src/impex/CMakeLists.txt
+++ b/src/impex/CMakeLists.txt
@@ -61,6 +61,12 @@ ADD_LIBRARY(vigraimpex ${LIBTYPE}
     viff.cxx
     void_vector.cxx)
 
+SET(VIGRA_IMPEX_EXTRA_C_FLAGS "" CACHE STRING 
+"Extra flags specifically for *.c files in vigra/impex. Useful for supporting old compilers and/or glibc versions.")
+IF(VIGRA_IMPEX_EXTRA_C_FLAGS)
+    SET_SOURCE_FILES_PROPERTIES(lz4.c iccjpeg.c rgbe.c PROPERTIES COMPILE_FLAGS "${VIGRA_IMPEX_EXTRA_C_FLAGS}")
+ENDIF()
+
 set(SOVERSION 6)  # increment this after changing the vigraimpex library
 IF(MACOSX)
     SET_TARGET_PROPERTIES(vigraimpex PROPERTIES VERSION ${SOVERSION}.${vigra_version} 


### PR DESCRIPTION
To get vigra to build on my special CentOS-5.11 VM (with special `gcc` binary), I needed to add some extra flags for the C files in `impex`.  This PR adds a variable to allow users to add compiler flags specifically for those C files.  (It shouldn't be needed on most systems.)

In case you're curious, the extra flags I'm using are:

    -DVIGRA_IMPEX_EXTRA_C_FLAGS="-std=gnu90 -Wno-pedantic -Wno-long-long"