### PR TITLE
Fix cmake issue when OpenMP is present

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,17 +95,6 @@ VIGRA_FIND_PACKAGE(FFTW3 NAMES libfftw3-3 libfftw-3.3)
 VIGRA_FIND_PACKAGE(FFTW3F NAMES libfftw3f-3 libfftwf-3.3)
 
 
-#FIND_PACKAGE( OpenMP REQUIRED)
-FIND_PACKAGE( OpenMP )
-if(OPENMP_FOUND)
-message("OPENMP FOUND")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
-endif()
-
-
-
 IF(WITH_OPENEXR)
     VIGRA_FIND_PACKAGE(OpenEXR)
 ENDIF()
@@ -165,8 +154,19 @@ ENDIF()
 include(VigraDetectThreading)
 include(VigraConfigureThreading)
 
+# Should come after VigraDetectThreading, since that updates the -std flag.
 include(VigraDetectCppVersion)
 VIGRA_DETECT_CPP_VERSION()
+
+# Put this last, because it can interfere with VigraDetectCppVersion, above.
+FIND_PACKAGE( OpenMP )
+if(OPENMP_FOUND)
+message("OPENMP FOUND")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
+endif()
+
 
 ##################################################
 #

--- a/config/VigraDetectCppVersion.cmake
+++ b/config/VigraDetectCppVersion.cmake
@@ -9,6 +9,13 @@ try_run(RUN_RESULT COMPILE_SUCCEEDED
         message(FATAL_ERROR "Failed to detect c++ version with a simple test program!  Compiler Output is below.\n"
                 "${COMPILE_OUTPUT_FROM_CPP_DETECT}")
     endif()
+
+    if(RUN_RESULT)
+        message(FATAL_ERROR "Failed to detect c++ version with a simple test program!\n"
+			    "Test program compiled, but did not execute cleanly. Run output is shown below.\n"
+ 			    "${VIGRA_CPP_VERSION}")
+    endif()
+
     message(STATUS "Detected C++ version: ${VIGRA_CPP_VERSION}")
 
 endmacro(VIGRA_DETECT_CPP_VERSION)


### PR DESCRIPTION
On mac, somehow the test program executed by `VigraDetectCppVersion.cmake` can fail to execute if it was compiled with `-fopenmp` but then can't locate `libgomp.dylib` at runtime.  This simple PR just re-orders cmake statements so that the CPP version is detected before `-fopenmp` is added to `CMAKE_CXX_FLAGS`.