### PR TITLE
hdf5impex.hxx:: openCreateGroup_():  H5LTfind_dataset call in openCreateGroup_ replaced

### DIFF
--- a/include/vigra/hdf5impex.hxx
+++ b/include/vigra/hdf5impex.hxx
@@ -45,6 +45,9 @@
 #define H5Dopen_vers 2
 #define H5Dcreate_vers 2
 #define H5Acreate_vers 2
+#define H5Eset_auto_vers 2
+#define H5Eget_auto_vers 2
+
 
 #include <hdf5.h>
 


### PR DESCRIPTION
H5LTfind_dataset calls are extremely slow as compared to checking return value of H5Gopen.
H5E calls used to temporarily suppress error output while probing H5Gopen()