### PR TITLE
Added FFTWLogMagnitudeAccessor

### DIFF
--- a/include/vigra/fftw.hxx
+++ b/include/vigra/fftw.hxx
@@ -604,6 +604,27 @@ class FFTWMagnitudeAccessor
 
 /* documentation: see fftw3.hxx
 */
+class FFTWLogMagnitudeAccessor
+{
+  public:
+        /// The accessor's value type.
+    typedef fftw_real value_type;
+
+        /// Read natural log of magnitude at iterator position.
+    template <class ITERATOR>
+    value_type operator()(ITERATOR const & i) const {
+        return std::log((*i).magnitude() + 1);
+    }
+
+        /// Read natural log of magnitude at offset from iterator position.
+    template <class ITERATOR, class DIFFERENCE>
+    value_type operator()(ITERATOR const & i, DIFFERENCE d) const {
+        return std::log((i[d]).magnitude() + 1);
+    }
+};
+
+/* documentation: see fftw3.hxx
+*/
 class FFTWPhaseAccessor
 {
   public:

--- a/include/vigra/fftw3.hxx
+++ b/include/vigra/fftw3.hxx
@@ -1393,6 +1393,32 @@ class FFTWMagnitudeAccessor
     }
 };
 
+    /** Calculate natural logarithm of magnitude of complex number on the fly.
+
+    <b>\#include</b> \<vigra/fftw3.hxx\> (for FFTW 3) or<br>
+    <b>\#include</b> \<vigra/fftw.hxx\> (for deprecated FFTW 2)<br>
+    Namespace: vigra
+    */
+template <class Real = double>
+class FFTWLogMagnitudeAccessor
+{
+  public:
+        /// The accessor's value type.
+    typedef Real value_type;
+
+        /// Read natural log of magnitude at iterator position.
+    template <class ITERATOR>
+    value_type operator()(ITERATOR const & i) const {
+        return std::log((*i).magnitude() + 1);
+    }
+
+        /// Read natural log of magnitude at offset from iterator position.
+    template <class ITERATOR, class DIFFERENCE>
+    value_type operator()(ITERATOR const & i, DIFFERENCE d) const {
+        return std::log((i[d]).magnitude() + 1);
+    }
+};
+
     /** Calculate phase of complex number on the fly.
 
     <b>\#include</b> \<vigra/fftw3.hxx\> (for FFTW 3) or<br>


### PR DESCRIPTION
Hi,

I added an logarithmic magnitude accessor for better visualization of fourier magnitude spectrums. I found it particularly useful in this context:
```
fourierTransform(input, fourier);
moveDCToCenter(srcImageRange(fourier), destImage(output));
exportImage(srcImageRange(output, FFTWLogMagnitudeAccessor<>()), "out.png");
```

Is this useful for the vigra project?

Regards,
Matthis