### PR TITLE
Reset MultiArrayView

### DIFF
--- a/include/vigra/multi_array.hxx
+++ b/include/vigra/multi_array.hxx
@@ -832,6 +832,16 @@ public:
         return MultiArrayView<N, T, StridedArrayTag>(m_shape, m_stride, m_ptr);
     }
 
+	/** Reset this <tt>MultiArrayView</tt> to an invalid state (as after default construction).
+		Can e.g. be used prior to assignment to make a view object point to new data.
+         */
+    void reset() {
+	m_shape = diff_zero_t(0);
+	m_stride = diff_zero_t(0);
+	m_ptr = 0;
+    }
+
+
         /** Assignment. There are 3 cases:
 
             <ul>

--- a/test/multiarray/test.cxx
+++ b/test/multiarray/test.cxx
@@ -449,7 +449,10 @@ public:
             std::string message(c.what());
             should(0 == expected.compare(message.substr(0,expected.size())));
         }
+	array.reset();
+	array = array3.subarray(Shape(0,0,0), Shape(10,1,1)); // possible after reset.
         MultiArrayView <3, scalar_type, array3_stride> subarray = array3.subarray(Shape(0,0,0), Shape(10,1,1));
+	should(subarray == array);
         subarray = array3.subarray(Shape(0,1,0), Shape(10,2,1)); // should overwrite the data
         for(unsigned int k=0; k<10; ++k)
             shouldEqual(array3(k,0,0), array3(k,1,0));


### PR DESCRIPTION
In some situations, I'd like to have the possibility to reset a
MultiArrayView object to the same state as after default construction
(i.e., an invalid MultiArrayView that can be assigned to).  

This is convenient if one uses MultiArrayViews objects (e.g. as
members of another object), and these need to change during the object
lifetime to point to different image data, for instance. Currently, I
don't see another way to "reset" an existing MultiArrayView object,
because assignment is defined such that it will either copy the data
(if shape matches) or fail, unless the object is in the "not
initialized yet" state as after default construction. Or am I
overlooking something?

Alternatives to the proposed implementation would perhaps be 
- to allow assignment of a default-constructed MultiArrayView unconditionally to perform the "reset";
- to make method reset(const MultiArrayView &rhs) perform the assignment right away.
- There's already method copy() to copy the data pointed to by the MultiArrayViews. One could therefore perhaps also opt to make operator= only perform a shallow copy of the pointer and shape/strides vectors (but that would of course have the severe drawback to alter existing semantics instead of just extending the interface of the class).

What do you think?
