### PR TITLE
Elminate FutureWarning in vigranumpy colors module

### DIFF
--- a/vigranumpy/src/core/colors.cxx
+++ b/vigranumpy/src/core/colors.cxx
@@ -382,7 +382,7 @@ void pythonGray2QImage_ARGB32Premultiplied(
     TmpType pixelF;
     
     TmpType normalizeLow, normalizeHigh; 
-    if(normalize != boost::python::object())
+    if(normalize.pyObject() != Py_None)
     {
         vigra_precondition(normalize.shape(0) == 2,
             "gray2qimage_ARGB32Premultiplied(): normalize.shape[0] == 2 required.");


### PR DESCRIPTION
This tiny change eliminates the following warning from numpy:

    FutureWarning: comparison to `None` will result in an elementwise object comparison in the future.