### PR TITLE
cmake: Always add Boost_INCLUDE_DIR to search path if WITH_BOOST is enabled.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,13 +123,16 @@ ENDIF()
 
 IF(WITH_BOOST)
     VIGRA_FIND_PACKAGE( Boost 1.40.0 COMPONENTS ${WITH_BOOST_COMPONENTS})
-    
-    if(Boost_FOUND AND WITH_BOOST_COMPONENTS)
-        # configure boost's autolink magic to use the right library name
-        # (default on Windows is a mangled name like 'boost_python-vc110-mt-1_51.lib')
-        if(("${Boost_PYTHON_LIBRARY}" MATCHES "boost_python\\.lib") OR
-           ("${Boost_SYSTEM_LIBRARY}" MATCHES "boost_system\\.lib"))
-            ADD_DEFINITIONS(-DBOOST_AUTO_LINK_NOMANGLE)
+
+    if(Boost_FOUND)
+        INCLUDE_DIRECTORIES(${Boost_INCLUDE_DIR})
+        if(WITH_BOOST_COMPONENTS)
+            # configure boost's autolink magic to use the right library name
+            # (default on Windows is a mangled name like 'boost_python-vc110-mt-1_51.lib')
+            if(("${Boost_PYTHON_LIBRARY}" MATCHES "boost_python\\.lib") OR
+               ("${Boost_SYSTEM_LIBRARY}" MATCHES "boost_system\\.lib"))
+                ADD_DEFINITIONS(-DBOOST_AUTO_LINK_NOMANGLE)
+            endif()
         endif()
     endif()
 ENDIF()


### PR DESCRIPTION
If boost is used in the build, we need to make sure that the boost include directory is added to the search path.  Previously, this was not guaranteed (depending on the file).  It usually worked in most cases, because most people keep their boost headers in a system prefix that is searched by the compiler anyway.

(I noticed this issue today when `adjacency_list_graph/test.cxx` failed to compile.)
