### PR TITLE
Kernel2D: added initExplicitly(BasicImage)

### DIFF
--- a/include/vigra/stdconvolution.hxx
+++ b/include/vigra/stdconvolution.hxx
@@ -1154,6 +1154,33 @@ public:
     {
         return initExplicitly(Shape2(upperleft), Shape2(lowerright));
     }
+	
+        /** Init the kernel by providing a BasicImage with the kernel values.
+
+            The norm is set to the sum of the image values. 
+
+            <b> Preconditions:</b>
+
+            odd image width and height;
+        */
+    Kernel2D & initExplicitly(BasicImage<value_type> const & image)
+    {
+        vigra_precondition(image.width() % 2 != 0 && image.height() % 2 != 0,
+                           "Kernel2D::initExplicitly(): kernel sizes must be odd.");
+
+        left_  = Point2D((image.width() - 1) / -2, (image.height() - 1) / -2);
+        right_ = Point2D((image.width() - 1) /  2, (image.height() - 1) /  2);
+
+		norm_ = 0;
+		for (typename BasicImage<value_type>::const_iterator iter = image.begin(); iter != image.end(); ++iter)
+		{
+			norm_ += *iter;
+		}
+
+		kernel_ = image;
+
+        return *this;
+    }
 
         /** Coordinates of the upper left corner of the kernel.
          */


### PR DESCRIPTION
Is there a way of initializing a custom kernel at runtime? 

The `initExplicitly` function cannot be used because it requires a comma-separated initializer list, which is why I came up with an overload to take a BasicImage which is then used as the kernel. Currently only odd kernel sizes are allowed to avoid the aligning ambiguities of even sized kernels. 

I could add support for MultiArray, even sized kernels, etc. But first, I wanted to show you the idea to see if you think, it's useful (or whether I missed an already available solution).

