### PR TITLE
Added `convolve` python bindings to support 4D arrays

### DIFF
--- a/vigranumpy/src/core/convolution.cxx
+++ b/vigranumpy/src/core/convolution.cxx
@@ -586,11 +586,19 @@ void defineConvolutionFunctions()
         (arg("volume"), arg("kernel"), arg("out")=python::object()),
         "Convolve a volume with the same 1D kernel along all dimensions.\n");
 
+    def("convolve", registerConverters(&pythonSeparableConvolveND_1Kernel<float,5>),
+        (arg("volume"), arg("kernel"), arg("out")=python::object()),
+        "Convolve a volume with the same 1D kernel along all dimensions.\n");
+
     def("convolve", registerConverters(&pythonSeparableConvolveND_NKernels<float,3>),
         (arg("image"), arg("kernels"), arg("out")=python::object()),
         "Convolve an image with a different 1D kernel along each dimensions.\n");
 
     def("convolve", registerConverters(&pythonSeparableConvolveND_NKernels<float,4>),
+        (arg("volume"), arg("kernels"), arg("out")=python::object()),
+        "Convolve a volume with a different 1D kernel along each dimensions.\n");
+
+    def("convolve", registerConverters(&pythonSeparableConvolveND_NKernels<float,5>),
         (arg("volume"), arg("kernels"), arg("out")=python::object()),
         "Convolve a volume with a different 1D kernel along each dimensions.\n");
 


### PR DESCRIPTION
Related: https://github.com/ukoethe/vigra/pull/199

This adds Python bindings for `convolve` to make sure it works on 4D arrays.