### PR TITLE
Removed extern "C" from unittest.hxx.

### DIFF
--- a/include/vigra/unittest.hxx
+++ b/include/vigra/unittest.hxx
@@ -240,8 +240,6 @@ int catch_signals( Generator function_object, detail::errstream & err, int timeo
 
 #elif defined(__unix)
 
-extern "C" {
-
 inline jmp_buf & unit_test_jump_buffer()
 {
     static jmp_buf unit_test_jump_buffer_;
@@ -252,8 +250,6 @@ static void unit_test_signal_handler(int sig)
 {
     longjmp(unit_test_jump_buffer(), sig);
 }
-
-} // extern "C"
 
 template< class Generator >  // Generator is function object returning int
 int catch_signals( Generator function_object, detail::errstream & err, int timeout)


### PR DESCRIPTION
The `extern "C"` part in `unittest.hxx` caused a compiler warning since it contained references, which are not supported in plain C. I removed it.