### PR TITLE
Fix for recent Doxygen versions: teach Doxygen that .dxx files should…

### DIFF
--- a/docsrc/Doxyfile.in
+++ b/docsrc/Doxyfile.in
@@ -1444,3 +1444,9 @@ DOT_CLEANUP            = YES
 # used. If set to NO the values of all tags below this one will be ignored.
 
 SEARCHENGINE           = NO
+
+# In recent versions of Doxygen, the documentation files with extension .dxx
+# are not recognised any more if we do not also add this option (in addition
+# to the file extension options elsewhere in the file). See here:
+# https://www.stack.nl/~dimitri/doxygen/manual/config.html#cfg_extension_mapping
+EXTENSION_MAPPING = dxx=C++


### PR DESCRIPTION
… be parsed as C++.

It it not enough any more to add ``.dxx`` to the list of extensions, we also need an ``EXTENSION_MAPPING`` configuration options that tells Doxygen to parse the files as C++.