### PR TITLE
Python3 fixes

### DIFF
--- a/config/FindVIGRANUMPY_DEPENDENCIES.cmake
+++ b/config/FindVIGRANUMPY_DEPENDENCIES.cmake
@@ -2,15 +2,13 @@
 #
 MESSAGE(STATUS "Checking VIGRANUMPY_DEPENDENCIES")
 
-FIND_PACKAGE(PythonInterp)
-
 IF(PYTHONINTERP_FOUND)
     # print out found Python version
     execute_process(COMMAND ${PYTHON_EXECUTABLE} -c
                          "import sys; print(sys.version[0])"
                           OUTPUT_VARIABLE PYTHON_MAJOR_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE)
     execute_process(COMMAND ${PYTHON_EXECUTABLE} -c
-                         "import sys; print(sys.version)"
+                         "import sys; print(sys.version.split()[0])"
                           OUTPUT_VARIABLE PYTHON_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE)
     MESSAGE(STATUS "Found Python ${PYTHON_VERSION}")
 #    this command cannot be used because its results are often inconsistent
@@ -31,7 +29,16 @@ IF(PYTHONINTERP_FOUND)
         execute_process(COMMAND ${PYTHON_EXECUTABLE} -c
                          "import sys; skip = 2 if sys.platform.startswith('win') else 1; print('python' + sys.version[0:3:skip])"
                           OUTPUT_VARIABLE PYTHON_LIBRARY_NAME OUTPUT_STRIP_TRAILING_WHITESPACE)
-        FIND_LIBRARY(PYTHON_LIBRARIES ${PYTHON_LIBRARY_NAME} HINTS "${PYTHON_PREFIX}" 
+        # NOTE: recent Python versions may add a trailing letter to the library name:
+        # https://www.python.org/dev/peps/pep-3149/
+        # We don't test for the debug version of the library, that adds the possibility
+        # of another "d" suffix.
+        FIND_LIBRARY(PYTHON_LIBRARIES
+                     "${PYTHON_LIBRARY_NAME}"
+                     "${PYTHON_LIBRARY_NAME}m"
+                     "${PYTHON_LIBRARY_NAME}u"
+                     "${PYTHON_LIBRARY_NAME}mu"
+                     HINTS "${PYTHON_PREFIX}"
                      PATH_SUFFIXES lib lib64 libs DOC "Python libraries")
     ENDIF()
 

--- a/config/VigraDetectThreading.cmake
+++ b/config/VigraDetectThreading.cmake
@@ -22,9 +22,13 @@ else()
     # Save original flags before we add new ones, in case there's no need for the new ones.
     set(ORIG_CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
 
+    if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+        SET(CMAKE_COMPILER_IS_CLANGXX 1)
+    endif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+
     if (CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.7.0")
         SET(CXX_THREADING_FLAGS "-pthread -std=c++0x")
-    elseif(CMAKE_COMPILER_IS_GNUCXX)
+    elseif(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANGXX)
         SET(CXX_THREADING_FLAGS "-pthread -std=c++11")
     elseif(NOT MSVC)
         SET(CXX_THREADING_FLAGS "-std=c++11")


### PR DESCRIPTION
This fixes compilation under Linux systems which adopt the new naming scheme for Python libraries (e.g., with trailing ``m``).

There's also a fix for clang compilation (missing ``-pthread`` flag). Does not properly belong to Python 3 fixes, but I figured that with all the ongoing changes in the build system it is easier to push it here.