### PR TITLE
Travis: Switch to container infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,21 @@ language: python
 python:
   - "2.7"
 
+
+sudo: false
+
+addons:
+  apt:
+    packages:
+      - libhdf5-serial-dev
+      - libboost-python-dev
+      - libjpeg-dev
+      - libtiff4-dev
+      - libpng12-dev
+      - libfftw3-dev
+      - cmake
+
 before_script:
-  - sudo apt-get update -qq
-  - sudo apt-get install --assume-yes libhdf5-serial-dev libboost-python-dev libjpeg-dev libtiff4-dev libpng12-dev libfftw3-dev cmake
   - pip install nose
   - pip install numpy
 


### PR DESCRIPTION
This should ideally speed up testing on Travis CI. Some packages have been added to a whitelist. All of the packages being installed by `apt-get` are on that whitelist. By using this whitelist, we no longer require `sudo`. By dropping `sudo`, we should be put on the container infrastructure that normally has faster startup times and often fewer users than the regular infrastructure.