### PR TITLE
Travis: Include ATLAS to speed up NumPy install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 
 before_script:
   - sudo apt-get update -qq
-  - sudo apt-get install --assume-yes libhdf5-serial-dev libboost-python-dev libjpeg-dev libtiff4-dev libpng12-dev libfftw3-dev cmake
+  - sudo apt-get install --assume-yes libhdf5-serial-dev libboost-python-dev libjpeg-dev libtiff4-dev libpng12-dev libfftw3-dev libatlas-base-dev cmake
   - pip install nose
   - pip install numpy
 


### PR DESCRIPTION
If NumPy doesn't find a BLAS, it builds a "lite" version of a BLAS itself, which takes awhile. By including a BLAS, we can skip this NumPy build step and see a substantial speed up in the build.