### PR TITLE
Boost thread pool (Pt. 2)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,13 +25,15 @@ matrix:
 
 addons:
   apt:
+    sources:
+      - boost-latest
     packages:
       - libhdf5-serial-dev
-      - libboost-thread-dev
-      - libboost-system-dev
-      - libboost-date_time-dev
-      - libboost-chrono-dev
-      - libboost-python-dev
+      - libboost-thread1.55-dev
+      - libboost-system1.55-dev
+      - libboost-date-time1.55-dev
+      - libboost-chrono1.55-dev
+      - libboost-python1.55-dev
       - libjpeg-dev
       - libtiff4-dev
       - libpng12-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
       sudo: false
       language: python
       python: "3.2"
-      env: WITH_BOOST_THREAD=1
+      env: WITH_BOOST_THREAD=1 CXXFLAGS="-pthread -std=c++0x"
     - os: osx
       osx_image: xcode7.3
       language: generic


### PR DESCRIPTION
Related: https://github.com/ukoethe/vigra/pull/316

This continues from the original PR ( https://github.com/ukoethe/vigra/pull/316 ) and tries to add support for Boost.Thread testing. It does this by taking advantage of the `apt-get` `sources` option on Travis to install a newer version Boost (1.55). ( https://docs.travis-ci.com/user/migrating-from-legacy/#Adding-APT-Sources )

Once this newer version is installed, we are ensured to have Boost.Chrono installed. Then it appears that we merely need to fix the C++ flags.

Not sure if you will accept this PR @ukoethe. Though having the `sources` option is probably worth porting over. Plus, it might nice to have at least one commit that has these fixes with the Python 3 fixes before removing it. Just a thought.