### PR TITLE
Python 3 Mac bottle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ before_script:
   - pip install nose
   - pip install numpy
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ ${TRAVIS_PYTHON_VERSION:0:1} -eq 2 ]]; then brew install boost-python --with-python ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ ${TRAVIS_PYTHON_VERSION:0:1} -eq 3 ]]; then brew install boost-python --without-python --with-python3 ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ ${TRAVIS_PYTHON_VERSION:0:1} -eq 3 ]]; then brew install "mac_homebrew_bottles/brew-python/${TRAVIS_PYTHON_VERSION}/boost-python-1.60.0.el_capitan.bottle.1.tar.gz" || brew install boost-python --without-python --with-python3 ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew cleanup --force -s; sudo rm -rf $(brew --cache)                                     ; fi
 
 script:


### PR DESCRIPTION
Adds a homebrew bottle (binary) for Boost.Python built for Python 3. This is used to speedup the Travis CI tests for Mac Python 3 by a few minutes (~6 mins). It will make the Python 3 and Python 2 tests on Mac take a comparable amount of time by skipping the otherwise necessary build step for Boost.Python on Python 3. This may also help avoid the infrequent hanging that sometimes occurs with the Mac Python 3 build. The bottle only takes up 6.7MB.