### PR TITLE
fix import error in ImagePyramid on python3

### DIFF
--- a/vigranumpy/lib/arraytypes.py
+++ b/vigranumpy/lib/arraytypes.py
@@ -2009,7 +2009,7 @@ class ImagePyramid(list):
         self[level][...] = image[...]
 
     def expandImpl(self, src, dest, centerValue):
-        import filters
+        import vigra.filters as filters
 
         ss, ds = src.shape, dest.shape
         s = [ss[k] if 2*ss[k] == ds[k] else -1 for k in range(len(ss))]
@@ -2030,7 +2030,7 @@ class ImagePyramid(list):
         '''
         # FIXME: This should be implemented in C++
         # FIXME: This should be implemented for arbitrary dimensions
-        import filters
+        import vigra.filters as filters
 
         if srcLevel > destLevel:
             raise RuntimeError("ImagePyramid::reduce(): srcLevel <= destLevel required.")
@@ -2069,7 +2069,7 @@ class ImagePyramid(list):
         '''
         # FIXME: This should be implemented in C++
         # FIXME: This should be implemented for arbitrary dimensions
-        import filters
+        import vigra.filters as filters
 
         if srcLevel > destLevel:
             raise RuntimeError("ImagePyramid::reduceLaplacian(): srcLevel <= destLevel required.")
@@ -2093,7 +2093,7 @@ class ImagePyramid(list):
         '''
         # FIXME: This should be implemented in C++
         # FIXME: This should be implemented for arbitrary dimensions
-        import filters
+        import vigra.filters as filters
 
         if srcLevel < destLevel:
             raise RuntimeError("ImagePyramid::expandLaplacian(): srcLevel >= destLevel required.")


### PR DESCRIPTION
```
In [1]: import vigra
In [2]: import numpy as np
In [3]: a = np.zeros((256,256))
In [4]: p = vigra.ImagePyramid(a)
In [5]: p.reduce(0,1)
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
<ipython-input-5-72316ca818cd> in <module>()
----> 1 p.reduce(0,1)

/usr/lib64/python3.4/site-packages/vigra/arraytypes.py in reduce(self, srcLevel, destLevel, centerValue)
   2031         # FIXME: This should be implemented in C++
   2032         # FIXME: This should be implemented for arbitrary dimensions
-> 2033         import filters
   2034
   2035         if srcLevel > destLevel:

ImportError: No module named 'filters'
```