### PR TITLE
Travis Linux Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,11 @@ matrix:
       language: python
       python: "3.2"
     - os: linux
+      dist: trusty
+      sudo: required
+      language: python
+      python: "3.4"
+    - os: linux
       sudo: false
       language: python
       python: "3.2"


### PR DESCRIPTION
This replaces the previous PR ( https://github.com/ukoethe/vigra/pull/309 ). 

Currently we have Python 3.2 testing on Linux, but it is a bit of an ancient version of Python 3. This adds testing for the more recent Python 3.4 on Linux. It may be worth discussing if we want to keep the Python 3.2 support or drop it in favor this.

This is currently blocked (WIP) because Travis CI is building Python with a static library on their Ubuntu Trusty VM. It is not possible for us to use the static Python library when building Boost.Python bindings to VIGRA. This can be easily fixed on their end by the addition of a single option when they build the various versions of Python that they include. Opened this issue to try and get Python built with a shared library on the Ubuntu Trusty VM ( https://github.com/travis-ci/travis-ci/issues/5533 ).
