### PR TITLE
Download Boost.Python bottle from casacore's bintray

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ before_script:
   - pip install nose
   - pip install numpy
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ ${TRAVIS_PYTHON_VERSION:0:1} -eq 2 ]]; then brew install boost-python --with-python ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ ${TRAVIS_PYTHON_VERSION:0:1} -eq 3 ]]; then brew install boost-python --without-python --with-python3 ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ ${TRAVIS_PYTHON_VERSION:0:1} -eq 3 ]]; then curl -L -O https://bintray.com/artifact/download/casacore/homebrew-bottles/boost-python-1.60.0.el_capitan.bottle.1.tar.gz && brew install ./boost-python-1.60.0.el_capitan.bottle.1.tar.gz ; rm -f ./boost-python-1.60.0.el_capitan.bottle.1.tar.gz ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew cleanup --force -s; sudo rm -rf $(brew --cache)                                     ; fi
 
 script:


### PR DESCRIPTION
Replaces https://github.com/ukoethe/vigra/pull/332.

Given it appears Travis's Mac Python 3 build is failing all the time, it seems better that we try to use someone's Boost.Python bottle for Python 3. Currently, the best solution I see, unless we switch to conda or someone would like to set up their own Bintray, is to use someone else's ( https://github.com/Homebrew/homebrew/issues/47218#issuecomment-177844653 ). They appear to have [incorporated]( https://github.com/casacore/casacore/pull/280 ) this into [`master`]( https://github.com/casacore/casacore/blob/master/.travis/install.sh#L10-L11 ) so I think we can count on this to work for the time being (until we switch to conda). I suppose this is better than simply bundling the binary in the repo ( https://github.com/ukoethe/vigra/pull/319 ) and is certainly better than just having these tests timeout.

Thoughts @ukoethe, @stuarteberg?