### PR TITLE
Travis Mac Build fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,8 @@ before_script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install $(echo -e $BREW_DEPS) || true                                          ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ ${TRAVIS_PYTHON_VERSION:0:1} -eq 3 ]]; then sudo ln -s /usr/local/bin/pip3 /usr/local/bin/pip ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ ${TRAVIS_PYTHON_VERSION:0:1} -eq 3 ]]; then sudo ln -s /usr/local/bin/python3 /usr/local/bin/python ; fi
+  - if [[ "$TRAVIS_PYTHON_VERSION" == "3.2" ]]; then pip install --upgrade 'pip<8' 'setuptools<19'                                ; fi
+  - if [[ "$TRAVIS_PYTHON_VERSION" != "3.2" ]]; then pip install --upgrade pip setuptools                                         ; fi
   - pip install nose
   - pip install numpy
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ ${TRAVIS_PYTHON_VERSION:0:1} -eq 2 ]]; then brew install boost-python --with-python ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,6 @@ addons:
 
 before_script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PATH="/usr/local/bin:${PATH}"                                                ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then travis_retry brew update                                                            ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew tap homebrew/science                                                           ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew remove --force $(grep -v -F -x -f <(cat <(brew deps --skip-optional --union $(echo -e $BREW_DEPS)) <(echo -e $BREW_DEPS))  <(cat <(brew leaves) <(brew deps --skip-optional --union $(brew leaves)))); brew cleanup --force ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew upgrade --cleanup $(echo -e $BREW_DEPS) || true                                ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,11 @@ matrix:
     - os: osx
       osx_image: xcode7.3
       language: generic
-      env: TRAVIS_PYTHON_VERSION="2" BREW_DEPS="cmake\nhdf5\nboost\nlibjpeg\nlibtiff\nlibpng\nfftw\nreadline"
+      env: TRAVIS_PYTHON_VERSION="2" BREW_DEPS="cmake\nhdf5\nboost\nlibjpeg\nlibtiff\nlibpng\nfftw\nreadline\npython"
     - os: osx
       osx_image: xcode7.3
       language: generic
-      env: TRAVIS_PYTHON_VERSION="3" BREW_DEPS="cmake\nhdf5\nboost\nlibjpeg\nlibtiff\nlibpng\nfftw\nreadline"
+      env: TRAVIS_PYTHON_VERSION="3" BREW_DEPS="cmake\nhdf5\nboost\nlibjpeg\nlibtiff\nlibpng\nfftw\nreadline\npython3"
 
 
 addons:
@@ -48,8 +48,6 @@ before_script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew remove --force $(grep -v -F -x -f <(cat <(brew deps --skip-optional --union $(echo -e $BREW_DEPS)) <(echo -e $BREW_DEPS))  <(cat <(brew leaves) <(brew deps --skip-optional --union $(brew leaves)))); brew cleanup --force ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew upgrade --cleanup $(echo -e $BREW_DEPS) || true                                ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install $(echo -e $BREW_DEPS) || true                                          ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ ${TRAVIS_PYTHON_VERSION:0:1} -eq 2 ]]; then brew install python                     ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ ${TRAVIS_PYTHON_VERSION:0:1} -eq 3 ]]; then brew install python3                    ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ ${TRAVIS_PYTHON_VERSION:0:1} -eq 3 ]]; then sudo ln -s /usr/local/bin/pip3 /usr/local/bin/pip ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ ${TRAVIS_PYTHON_VERSION:0:1} -eq 3 ]]; then sudo ln -s /usr/local/bin/python3 /usr/local/bin/python ; fi
   - pip install nose

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,10 +43,11 @@ addons:
 
 before_script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PATH="/usr/local/bin:${PATH}"                                                ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew remove --force $(brew list); brew cleanup --force                              ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then travis_retry brew update                                                            ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew tap homebrew/science                                                           ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install $(echo -e $BREW_DEPS)                                                  ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew remove --force $(grep -v -F -x -f <(cat <(brew deps --skip-optional --union $(echo -e $BREW_DEPS)) <(echo -e $BREW_DEPS))  <(cat <(brew leaves) <(brew deps --skip-optional --union $(brew leaves)))); brew cleanup --force ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew upgrade --cleanup $(echo -e $BREW_DEPS) || true                                ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install $(echo -e $BREW_DEPS) || true                                          ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ ${TRAVIS_PYTHON_VERSION:0:1} -eq 2 ]]; then brew install python                     ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ ${TRAVIS_PYTHON_VERSION:0:1} -eq 3 ]]; then brew install python3                    ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ ${TRAVIS_PYTHON_VERSION:0:1} -eq 3 ]]; then sudo ln -s /usr/local/bin/pip3 /usr/local/bin/pip ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,11 @@ matrix:
     - os: osx
       osx_image: xcode7.3
       language: generic
-      env: TRAVIS_PYTHON_VERSION="2"
+      env: TRAVIS_PYTHON_VERSION="2" BREW_DEPS="cmake\nhdf5\nboost\nlibjpeg\nlibtiff\nlibpng\nfftw\nreadline"
     - os: osx
       osx_image: xcode7.3
       language: generic
-      env: TRAVIS_PYTHON_VERSION="3"
+      env: TRAVIS_PYTHON_VERSION="3" BREW_DEPS="cmake\nhdf5\nboost\nlibjpeg\nlibtiff\nlibpng\nfftw\nreadline"
 
 
 addons:
@@ -46,14 +46,7 @@ before_script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew remove --force $(brew list); brew cleanup --force                              ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then travis_retry brew update                                                            ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew tap homebrew/science                                                           ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install cmake                                                                  ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install hdf5                                                                   ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install boost                                                                  ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install libjpeg                                                                ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install libtiff                                                                ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install libpng                                                                 ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install fftw                                                                   ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install readline                                                               ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install $(echo -e $BREW_DEPS)                                                  ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ ${TRAVIS_PYTHON_VERSION:0:1} -eq 2 ]]; then brew install python                     ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ ${TRAVIS_PYTHON_VERSION:0:1} -eq 3 ]]; then brew install python3                    ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ ${TRAVIS_PYTHON_VERSION:0:1} -eq 3 ]]; then sudo ln -s /usr/local/bin/pip3 /usr/local/bin/pip ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ before_script:
   - pip install nose
   - pip install numpy
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ ${TRAVIS_PYTHON_VERSION:0:1} -eq 2 ]]; then brew install boost-python --with-python ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ ${TRAVIS_PYTHON_VERSION:0:1} -eq 3 ]]; then brew install boost-python --without-python --with-python3 ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ ${TRAVIS_PYTHON_VERSION:0:1} -eq 3 ]]; then curl -L -O https://bintray.com/artifact/download/casacore/homebrew-bottles/boost-python-1.60.0.el_capitan.bottle.1.tar.gz && brew install ./boost-python-1.60.0.el_capitan.bottle.1.tar.gz ; rm -f ./boost-python-1.60.0.el_capitan.bottle.1.tar.gz ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew cleanup --force -s; sudo rm -rf $(brew --cache)                                     ; fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,4 +68,5 @@ script:
   - mkdir build && cd build
   - cmake -DCMAKE_BUILD_TYPE=Release -DTEST_VIGRANUMPY=1 -DDEPENDENCY_SEARCH_PREFIX=$VIRTUAL_ENV -DAUTOBUILD_TESTS=1 -DAUTOEXEC_TESTS=0 -DWITH_BOOST_THREAD=$WITH_BOOST_THREAD -DBoost_DEBUG=1 -DPYTHON_VERSION=${TRAVIS_PYTHON_VERSION:0:3} ..
   - make
+  - find . -name "*.o" | xargs rm -v
   - ctest --output-on-failure

--- a/include/vigra/config_version.hxx
+++ b/include/vigra/config_version.hxx
@@ -38,8 +38,8 @@
 #define VIGRA_CONFIG_VERSION_HXX
 
     #define VIGRA_VERSION_MAJOR 1
-    #define VIGRA_VERSION_MINOR 10
+    #define VIGRA_VERSION_MINOR 11
     #define VIGRA_VERSION_PATCH 0
-    #define VIGRA_VERSION "1.10.0"
+    #define VIGRA_VERSION "1.11.0"
 
 #endif /* VIGRA_CONFIG_VERSION_HXX */

--- a/vigranumpy/lib/__init__.py
+++ b/vigranumpy/lib/__init__.py
@@ -636,32 +636,6 @@ _genTensorConvenienceFunctions()
 del _genTensorConvenienceFunctions
 
 
-
-
-
-# define tensor convenience functions
-def _genDistanceTransformFunctions():
-
-    def distanceTransform(array,background=True,norm=2,pixel_pitch=None, out=None):
-        if array.squeeze().ndim == 2:
-            return filters.distanceTransform2D(array,background=background,norm=norm,
-                                               pixel_pitch=pixel_pitch, out=out)
-        elif array.squeeze().ndim == 3:
-            return filters.distanceTransform3D(array.astype('float32'),background=background,norm=2)
-        else:
-            raise RuntimeError("distanceTransform is only implemented for 2D and 3D arrays")
-
-    distanceTransform.__module__ = 'vigra.filters'
-    filters.distanceTransform = distanceTransform
-
-
-
-_genDistanceTransformFunctions()
-del _genDistanceTransformFunctions
-
-
-
-
 # define feature convenience functions
 def _genFeaturConvenienceFunctions():
     def supportedFeatures(array):

--- a/vigranumpy/lib/__init__.py
+++ b/vigranumpy/lib/__init__.py
@@ -311,14 +311,17 @@ def gaussianDerivative(array, sigma, orders, out=None, window_size=0.0):
 
         'window_size' specifies the ratio between the filter scale and the size of
         the filter window. Use values around 2.0 to speed-up the computation for the
-        price of increased cut-off error, and values >= 4.0 for vary accurate results.
+        price of increased cut-off error, and values >= 4.0 for very accurate results.
         The window size is automatically determined for the default value 0.0.
+
+        For the first and second derivatives, you can also use :func:`gaussianGradient`
+        and :func:`hessianOfGaussian`.
     '''
     if hasattr(array, 'dropChannelAxis'):
         if array.dropChannelAxis().ndim != len(orders):
             raise RuntimeError("gaussianDerivative(): len(orders) doesn't match array dimension.")
     else:
-        if array.ndim == len(orders):
+        if array.ndim != len(orders):
             raise RuntimeError("gaussianDerivative(): len(orders) doesn't match array dimension.")
     try:
         len(sigma)

--- a/vigranumpy/lib/ufunc.py
+++ b/vigranumpy/lib/ufunc.py
@@ -1,36 +1,36 @@
 ﻿#######################################################################
-#                                                                      
-#         Copyright 2009-2010 by Ullrich Koethe                        
-#                                                                      
-#    This file is part of the VIGRA computer vision library.           
-#    The VIGRA Website is                                              
-#        http://hci.iwr.uni-heidelberg.de/vigra/                       
-#    Please direct questions, bug reports, and contributions to        
-#        ullrich.koethe@iwr.uni-heidelberg.de    or                    
-#        vigra@informatik.uni-hamburg.de                               
-#                                                                      
-#    Permission is hereby granted, free of charge, to any person       
-#    obtaining a copy of this software and associated documentation    
-#    files (the "Software"), to deal in the Software without           
-#    restriction, including without limitation the rights to use,      
-#    copy, modify, merge, publish, distribute, sublicense, and/or      
-#    sell copies of the Software, and to permit persons to whom the    
-#    Software is furnished to do so, subject to the following          
-#    conditions:                                                       
-#                                                                      
-#    The above copyright notice and this permission notice shall be    
-#    included in all copies or substantial portions of the             
-#    Software.                                                         
-#                                                                      
-#    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND    
-#    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES   
-#    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND          
-#    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT       
-#    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,      
-#    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING      
-#    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR     
-#    OTHER DEALINGS IN THE SOFTWARE.                                   
-#                                                                      
+#
+#         Copyright 2009-2010 by Ullrich Koethe
+#
+#    This file is part of the VIGRA computer vision library.
+#    The VIGRA Website is
+#        http://hci.iwr.uni-heidelberg.de/vigra/
+#    Please direct questions, bug reports, and contributions to
+#        ullrich.koethe@iwr.uni-heidelberg.de    or
+#        vigra@informatik.uni-hamburg.de
+#
+#    Permission is hereby granted, free of charge, to any person
+#    obtaining a copy of this software and associated documentation
+#    files (the "Software"), to deal in the Software without
+#    restriction, including without limitation the rights to use,
+#    copy, modify, merge, publish, distribute, sublicense, and/or
+#    sell copies of the Software, and to permit persons to whom the
+#    Software is furnished to do so, subject to the following
+#    conditions:
+#
+#    The above copyright notice and this permission notice shall be
+#    included in all copies or substantial portions of the
+#    Software.
+#
+#    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND
+#    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+#    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+#    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+#    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+#    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+#    OTHER DEALINGS IN THE SOFTWARE.
+#
 #######################################################################
 
 import numpy
@@ -38,65 +38,65 @@ import copy
 
 vigraTypecastingRules = '''
 Default output types are thus determined according to the following rules:
-   
+
    1. The output type does not depend on the order of the arguments::
-   
+
          a + b results in the same type as b + a
-   
-   2.a With exception of logical functions and abs(), the output type 
+
+   2.a With exception of logical functions and abs(), the output type
        does not depend on the function to be executed.
-        
-   2.b The output type of logical functions is bool. 
-   
-   2.c The output type of abs() follows general rules unless the 
-       input contains complex numbers, in which case the output type 
+
+   2.b The output type of logical functions is bool.
+
+   2.c The output type of abs() follows general rules unless the
+       input contains complex numbers, in which case the output type
        is the corresponding float number type::
-      
+
          a + b results in the same type as a / b
          a == b => bool
          abs(complex128) => float64
-         
+
    3. If the inputs have the same type, the type is preserved::
-   
+
          uint8 + uint8 => uint8
-   
-   4. If (and only if) one of the inputs has at least 64 bits, the output 
+
+   4. If (and only if) one of the inputs has at least 64 bits, the output
       will also have at least 64 bits::
-      
+
          int64 + uint32 => int64
          int64 + 1.0    => float64
-         
+
    5. If an array is combined with a scalar of the same kind (integer,
-      float, or complex), the array type is preserved. If an integer 
-      array with at most 32 bits is combined with a float scalar, the 
+      float, or complex), the array type is preserved. If an integer
+      array with at most 32 bits is combined with a float scalar, the
       result is float32 (and rule 4 kicks in if the array has 64 bits)::
-      
+
          uint8   + 1   => uint8
          uint8   + 1.0 => float32
          float32 + 1.0 => float32
          float64 + 1.0 => float64
-         
+
    6. Integer expressions with mixed types always produce signed results.
-      If the arguments have at most 32 bits, the result will be int32, 
+      If the arguments have at most 32 bits, the result will be int32,
       otherwise it will be int64 (cf. rule 4)::
-      
+
          int8  + uint8  => int32
          int32 + uint8  => int32
          int32 + uint32 => int32
          int32 + int64  => int64
          int64 + uint64 => int64
-         
-   7. In all other cases, the output type is equal to the highest input 
+
+   7. In all other cases, the output type is equal to the highest input
       type::
-      
+
          int32   + float32    => float32
          float32 + complex128 => complex128
-         
+
    8. All defaults can be overridden by providing an explicit output array::
-   
+
          ufunc.add(uint8, uint8, uint16) => uint16
-         
-In order to prevent overflow, necessary upcasting is performed before 
+
+In order to prevent overflow, necessary upcasting is performed before
 the function is executed.
 '''
 
@@ -106,7 +106,7 @@ class Function(object):
     kindToNumber = {'b': 1, 'u': 2, 'i': 2, 'f': 3, 'c': 4}
     boolFunctions = ['equal', 'greater', 'greater_equal', 'less', 'less_equal', 'not_equal',
                      'logical_and', 'logical_not', 'logical_or', 'logical_xor']
-    
+
     def __init__(self, function):
         self.function = function
         self.is_bool = function.__name__ in self.boolFunctions
@@ -114,16 +114,16 @@ class Function(object):
         self.__doc__ = function.__doc__
         self.nin = function.nin
         self.nout = function.nout
-        
+
     def __getattr__(self, name):
         return getattr(self.function, name)
-        
+
     def __repr__(self):
         return "<vigra.ufunc '%s'>" % self.__name__
-    
+
     def priorities(self, *args):
-        '''Among the inputs with largest size, find the one with highest 
-           __array_priority__. Return this input, or None if there is no 
+        '''Among the inputs with largest size, find the one with highest
+           __array_priority__. Return this input, or None if there is no
            inputs with 'size' and '__array_priority__' defined.'''
         maxSize = max([getattr(x, 'size', 0) for x in args])
         if maxSize == 0:
@@ -134,7 +134,7 @@ class Function(object):
             return None
         else:
             return priorities[-1][1]
-    
+
     def common_type_numpy(self, *args):
         '''Find a common type for the given inputs.
            This function will become obsolete when numpy.find_common_type() will be fixed.
@@ -163,14 +163,14 @@ class Function(object):
                (h == 'c' and s == 'c'):
                 return (highestArrayType, highestArrayType)
             return (highestArrayType, scalarTypes[0])
-        
+
     def common_type(self, *args):
-        '''Find the appropriate pair (in_dtype, out_dtype) according to 
-           vigranumpy typecasting rules. in_dtype is the type into which 
+        '''Find the appropriate pair (in_dtype, out_dtype) according to
+           vigranumpy typecasting rules. in_dtype is the type into which
            the arguments will be casted before performing the operation
            (to prevent possible overflow), out_type is the type the output
            array will have (unless an explicit out-argument is provided).
-           
+
            See ufunc.vigraTypecastingRules for detailed information on coercion rules.
         '''
         if self.is_abs and args[0].dtype.kind == "c" and args[1] is None:
@@ -184,13 +184,13 @@ class Function(object):
         arrayTypes = [(self.kindToNumber[x.dtype.kind], x.dtype.itemsize, x.dtype) for x in args if hasattr(x, 'dtype')]
         arrayTypes.sort()
         if arrayTypes[0] != arrayTypes[-1] and arrayTypes[-1][0] == 2:
-            if arrayTypes[-1][1] <= 4: 
+            if arrayTypes[-1][1] <= 4:
                 highestArrayType = (2, 4, numpy.int32)
-            else: 
+            else:
                 highestArrayType = (2, 8, numpy.int64)
         else:
             highestArrayType = arrayTypes[-1]
-            
+
         if self.is_bool:
             return (highestArrayType[-1], numpy.bool8)
 
@@ -201,15 +201,15 @@ class Function(object):
         if highestArrayType[0] >= scalarType[0]:
             return (highestArrayType[-1], highestArrayType[-1])
         elif scalarType[0] == 3 and highestArrayType[1] <= 4:
-            return (highestArrayType[-1], numpy.float32)        
+            return (highestArrayType[-1], numpy.float32)
         else:
-            return (highestArrayType[-1], scalarType[-1])        
-        
+            return (highestArrayType[-1], scalarType[-1])
+
 class UnaryFunction(Function):
     def __call__(self, arg, out=None):
         a = arg.squeeze().transposeToNumpyOrder()
         dtype, out_dtype = self.common_type(a, out)
-        
+
         if out is None:
             out = arg.__class__(arg, dtype=out_dtype, order='A', init=False)
             o = out.squeeze().transposeToNumpyOrder()
@@ -217,10 +217,10 @@ class UnaryFunction(Function):
             o = out.squeeze().transposeToNumpyOrder()
             if not a.axistags.compatible(o.axistags):
                 raise RuntimeError("%s(): axistag mismatch" % self.function.__name__)
-        
+
         a = numpy.require(a, dtype).view(numpy.ndarray) # view(ndarray) prevents infinite recursion
         self.function(a, o)
-        return out            
+        return out
 
 class UnaryFunctionOut2(Function):
     def __call__(self, arg, out1=None, out2=None):
@@ -236,40 +236,43 @@ class UnaryFunctionOut2(Function):
                 raise RuntimeError("%s(): axistag mismatch" % self.function.__name__)
 
         if out2 is None:
-            out2 = arg.__class__(arg, dtype=out_dtype, order='A', init=False)            
+            out2 = arg.__class__(arg, dtype=out_dtype, order='A', init=False)
             o2 = out2.squeeze().transposeToNumpyOrder()
         else:
             o2 = out2.squeeze().transposeToNumpyOrder()
             if not a.axistags.compatible(o2.axistags):
                 raise RuntimeError("%s(): axistag mismatch" % self.function.__name__)
-            
+
         a = numpy.require(a, dtype).view(numpy.ndarray) # view(ndarray) prevents infinite recursion
         self.function(a, o1, o2)
         return out1, out2
-                
+
 class BinaryFunction(Function):
     def __call__(self, arg1, arg2, out=None):
+        if arg1.__class__ is numpy.ndarray or arg2.__class__ is numpy.ndarray:
+            return self.function(arg1, arg2, out)
+
         dtype, out_dtype = self.common_type(arg1, arg2, out)
-        
+
         if isinstance(arg1, numpy.ndarray):
             a1 = arg1.transposeToNumpyOrder()
             if isinstance(arg2, numpy.ndarray):
                 a2 = arg2.transposeToNumpyOrder()
-                
+
                 if arg1.__array_priority__ == arg2.__array_priority__:
                     priorityArg = arg2 if arg1.ndim < arg2.ndim else arg1
                 else:
                     priorityArg = arg2 if arg1.__array_priority__ < arg2.__array_priority__ else arg1
-                
+
                 if a1.ndim < a2.ndim:
                     a1 = a1.insertChannelAxis(order='C')
                 elif a1.ndim > a2.ndim:
                     a2 = a2.insertChannelAxis(order='C')
-                    
+
                 axistags = a1.axistags
-                
+
                 if not axistags.compatible(a2.axistags):
-                    raise RuntimeError("%s(): input axistag mismatch %r vs. %r" % 
+                    raise RuntimeError("%s(): input axistag mismatch %r vs. %r" %
                                          (self.function.__name__, axistags, a2.axistags))
                 shape = tuple(max(k) for k in zip(a1.shape, a2.shape))
                 a2 = numpy.require(a2, dtype).view(numpy.ndarray)
@@ -286,7 +289,7 @@ class BinaryFunction(Function):
             shape = a2.shape
             priorityArg = arg2
             a2 = numpy.require(a2, dtype).view(numpy.ndarray)
-            
+
         if out is None:
             outClass = priorityArg.__class__
             inversePermutation = priorityArg.permutationFromNumpyOrder()
@@ -300,11 +303,11 @@ class BinaryFunction(Function):
             if o.ndim < len(shape):
                 o = o.insertChannelAxis(order='C')
             if not axistags.compatible(o.axistags):
-                raise RuntimeError("%s(): output axistag mismatch %r vs. %r" % 
+                raise RuntimeError("%s(): output axistag mismatch %r vs. %r" %
                                          (self.function.__name__, axistags, o.axistags))
         self.function(a1, a2, o)
         return out
-        
+
 __all__ = []
 
 for _k in numpy.__dict__.values():
@@ -323,10 +326,10 @@ def _prepareDoc():
     doc = '''
 The following mathematical functions are available in this module
 (refer to numpy for detailed documentation)::
-    
+
 '''
 
-    k = 0    
+    k = 0
     while k < len(__all__):
         t = 8
         while True:
@@ -338,7 +341,7 @@ The following mathematical functions are available in this module
         k += t
 
     return doc + '''
-Some of these functions are also provided as member functions of 
+Some of these functions are also provided as member functions of
 VigraArray::
 
     __abs__   __add__   __and__   __div__   __divmod__   __eq__
@@ -354,14 +357,14 @@ As usual, these functions are applied independently at each pixel.
 Vigranumpy overloads the numpy-versions of these functions in order to make their
 behavior more suitable for image analysis. In particular, we changed two aspects:
 
-* Axistag consistency is checked, and the order of axes and strides is 
-  preserved in the result array. (In contrast, plain numpy functions 
-  always create C-order arrays, disregarding the stride order of the 
+* Axistag consistency is checked, and the order of axes and strides is
+  preserved in the result array. (In contrast, plain numpy functions
+  always create C-order arrays, disregarding the stride order of the
   inputs.)
-* Typecasting rules are changed such that (i) data are represented with 
-  at most 32 bits, when possible, (ii) the number of types that occur as 
-  results of mixed expressions is reduced, and (iii) the chance of bad 
-  surprises is minimized. 
+* Typecasting rules are changed such that (i) data are represented with
+  at most 32 bits, when possible, (ii) the number of types that occur as
+  results of mixed expressions is reduced, and (iii) the chance of bad
+  surprises is minimized.
 
 ''' + vigraTypecastingRules
 

--- a/vigranumpy/src/core/pythonaccumulator.hxx
+++ b/vigranumpy/src/core/pythonaccumulator.hxx
@@ -331,7 +331,7 @@ struct PythonRegionFeatureAccumulator
 {
     virtual MultiArrayIndex maxRegionLabel() { throw std::runtime_error("abstract function called."); }
     virtual void mergeAll(PythonRegionFeatureAccumulator const & o) { throw std::runtime_error("abstract function called."); }
-    virtual void remappingMerge(PythonFeatureAccumulator const & o, NumpyArray<1, npy_uint32> labelMapping) { throw std::runtime_error("abstract function called."); }
+    virtual void remappingMerge(PythonRegionFeatureAccumulator const & o, NumpyArray<1, npy_uint32> labelMapping) { throw std::runtime_error("abstract function called."); }
     virtual void mergeRegions(npy_uint32 i, npy_uint32 j) { throw std::runtime_error("abstract function called."); }
     virtual PythonRegionFeatureAccumulator * create() const { throw std::runtime_error("abstract function called."); return 0; }
     
@@ -455,7 +455,7 @@ struct PythonAccumulator
         merge(o);
     }
     
-    void remappingMerge(PythonFeatureAccumulator const & o, NumpyArray<1, npy_uint32> labelMapping)
+    void remappingMerge(PythonRegionFeatureAccumulator const & o, NumpyArray<1, npy_uint32> labelMapping)
     {
         PythonAccumulator const * p = dynamic_cast<PythonAccumulator const *>(&o);
         if(p == 0)

--- a/vigranumpy/src/core/segmentation.cxx
+++ b/vigranumpy/src/core/segmentation.cxx
@@ -56,6 +56,9 @@
 #include <string>
 #include <cmath>
 
+#include <boost/python/stl_iterator.hpp>
+#include <boost/unordered_map.hpp>
+
 #include "tws.hxx"
 
 namespace python = boost::python;
@@ -1078,6 +1081,72 @@ python::tuple  pyUnionFindWatershedsBlockwise(
     return python::make_tuple(out, nSeg);
 }
 
+/** \brief Map all values in src to new values using the given mapping (a dict).
+ *  See python docstring for details.
+*/
+template <unsigned int NDIM, class SrcVoxelType, class DestVoxelType>
+NumpyAnyArray
+pythonApplyMapping(NumpyArray<NDIM, Singleband<SrcVoxelType> > src,
+                   python::dict mapping,
+                   bool allow_incomplete_mapping = false,
+                   NumpyArray<NDIM, Singleband<DestVoxelType> > res = NumpyArray<NDIM, Singleband<SrcVoxelType> >())
+{
+    using namespace boost::python;
+
+    res.reshapeIfEmpty(src.taggedShape(), "applyMapping(): Output array has wrong shape.");
+
+    // Copy dict into a c++ unordered_map of ints,
+    // which is ~10x faster than using a Python dict
+    typedef boost::unordered_map<SrcVoxelType, DestVoxelType> labelmap_t;
+    labelmap_t labelmap(2*len(mapping)); // Using 2*N buckets seems to speed things up by 10%
+
+    typedef stl_input_iterator<tuple> dict_iter_t;
+
+#if PY_MAJOR_VERSION < 3
+    dict_iter_t map_iter = mapping.iteritems();
+#else
+    dict_iter_t map_iter = mapping.items();
+#endif
+
+    for (; map_iter != dict_iter_t(); ++map_iter)
+    {
+        object key = (*map_iter)[0];
+        object value = (*map_iter)[1];
+        labelmap[extract<SrcVoxelType>(key)] = extract<DestVoxelType>(value);
+    }
+
+    {
+        PyAllowThreads _pythread;
+
+        if (allow_incomplete_mapping)
+        {
+            transformMultiArray(src, res,
+                [&labelmap](SrcVoxelType px) -> DestVoxelType {
+                    typename labelmap_t::const_iterator iter = labelmap.find(px);
+                    if (iter == labelmap.end())
+                    {
+                        // Key is missing. Return the original value.
+                        return static_cast<DestVoxelType>(px);
+                    }
+                    return iter->second;
+                });
+        }
+        else
+        {
+            transformMultiArray(src, res,
+                [&labelmap](SrcVoxelType px) -> DestVoxelType {
+                    return labelmap.at(px);
+                });
+        }
+    }
+
+    return res;
+}
+
+// Unfortunately, can't use this macro because the template args uses TWO dtypes
+//VIGRA_PYTHON_MULTITYPE_FUNCTOR_NDIM(pyApplyMapping, pythonApplyMapping)
+
+
 void defineSegmentation()
 {
     using namespace python;
@@ -1452,6 +1521,79 @@ void defineSegmentation()
         "\n"
         "The function returns a Python tuple (labelImage, maxRegionLabel)\n"
         "\n");
+
+    // Lots of overloads here to allow mapping between arrays of different dtypes.
+    // -- 3D
+    // 8 <--> 8, 32 <--> 32, 64 <--> 64
+    def("applyMapping", registerConverters(&pythonApplyMapping<3, npy_uint32, npy_uint32>),
+        (arg("labels"), arg("mapping"), arg("allow_incomplete_mapping")=false, arg("out")=python::object()),
+        "Map all values in `labels` to new values using the given mapping (a dict).\n"
+        "Useful for maps with large values, for which a numpy index array would need too much RAM.\n"
+        "To relabel in-place, set `out=labels`.\n"
+        "\n"
+        "Parameters\n"
+        "----------\n"
+        "labels: ndarray\n"
+        "mapping: dict of ``{old_label : new_label}``\n"
+        "allow_incomplete_mapping: If True, then any voxel values in the original data that are missing\n"
+        "                          from the mapping dict will be copied (and casted) into the output.\n"
+        "                          Otherwise, an ``IndexError`` will be raised if the map is incomplete\n"
+        "                          for the input data.\n"
+        "out: ndarray to hold the data. If None, it will be allocated for you.\n"
+        "     The dtype of ``out`` is allowed to be smaller (or bigger) than the dtype of ``labels``.\n"
+        "\n"
+        "Note: As with other vigra functions, you should provide accurate axistags for optimal performance.\n");
+    def("applyMapping", registerConverters(&pythonApplyMapping<3, npy_uint64, npy_uint64>), (arg("src"), arg("mapping"), arg("allow_incomplete_mapping")=false, arg("out")=python::object()));
+    def("applyMapping", registerConverters(&pythonApplyMapping<3, npy_uint8, npy_uint8>),   (arg("src"), arg("mapping"), arg("allow_incomplete_mapping")=false, arg("out")=python::object()));
+
+    // 8 <--> 32
+    def("applyMapping", registerConverters(&pythonApplyMapping<3, npy_uint8, npy_uint32>), (arg("src"), arg("mapping"), arg("allow_incomplete_mapping")=false, arg("out")=python::object()));
+    def("applyMapping", registerConverters(&pythonApplyMapping<3, npy_uint32, npy_uint8>), (arg("src"), arg("mapping"), arg("allow_incomplete_mapping")=false, arg("out")=python::object()));
+
+    // 32 <--> 64
+    def("applyMapping", registerConverters(&pythonApplyMapping<3, npy_uint32, npy_uint64>), (arg("src"), arg("mapping"), arg("allow_incomplete_mapping")=false, arg("out")=python::object()));
+    def("applyMapping", registerConverters(&pythonApplyMapping<3, npy_uint64, npy_uint32>), (arg("src"), arg("mapping"), arg("allow_incomplete_mapping")=false, arg("out")=python::object()));
+
+    // 8 <--> 64
+    def("applyMapping", registerConverters(&pythonApplyMapping<3, npy_uint8, npy_uint64>), (arg("src"), arg("mapping"), arg("allow_incomplete_mapping")=false, arg("out")=python::object()));
+    def("applyMapping", registerConverters(&pythonApplyMapping<3, npy_uint64, npy_uint8>), (arg("src"), arg("mapping"), arg("allow_incomplete_mapping")=false, arg("out")=python::object()));
+
+    // -- 2D
+    // 8 <--> 8, 32 <--> 32, 64 <--> 64
+    def("applyMapping", registerConverters(&pythonApplyMapping<2, npy_uint32, npy_uint32>), (arg("src"), arg("mapping"), arg("allow_incomplete_mapping")=false, arg("out")=python::object()));
+    def("applyMapping", registerConverters(&pythonApplyMapping<2, npy_uint64, npy_uint64>), (arg("src"), arg("mapping"), arg("allow_incomplete_mapping")=false, arg("out")=python::object()));
+    def("applyMapping", registerConverters(&pythonApplyMapping<2, npy_uint8, npy_uint8>),   (arg("src"), arg("mapping"), arg("allow_incomplete_mapping")=false, arg("out")=python::object()));
+
+    // 8 <--> 32
+    def("applyMapping", registerConverters(&pythonApplyMapping<2, npy_uint8, npy_uint32>), (arg("src"), arg("mapping"), arg("allow_incomplete_mapping")=false, arg("out")=python::object()));
+    def("applyMapping", registerConverters(&pythonApplyMapping<2, npy_uint32, npy_uint8>), (arg("src"), arg("mapping"), arg("allow_incomplete_mapping")=false, arg("out")=python::object()));
+
+    // 32 <--> 64
+    def("applyMapping", registerConverters(&pythonApplyMapping<2, npy_uint32, npy_uint64>), (arg("src"), arg("mapping"), arg("allow_incomplete_mapping")=false, arg("out")=python::object()));
+    def("applyMapping", registerConverters(&pythonApplyMapping<2, npy_uint64, npy_uint32>), (arg("src"), arg("mapping"), arg("allow_incomplete_mapping")=false, arg("out")=python::object()));
+
+    // 8 <--> 64
+    def("applyMapping", registerConverters(&pythonApplyMapping<2, npy_uint8, npy_uint64>), (arg("src"), arg("mapping"), arg("allow_incomplete_mapping")=false, arg("out")=python::object()));
+    def("applyMapping", registerConverters(&pythonApplyMapping<2, npy_uint64, npy_uint8>), (arg("src"), arg("mapping"), arg("allow_incomplete_mapping")=false, arg("out")=python::object()));
+
+    // -- 1D
+    // 8 <--> 8, 32 <--> 32, 64 <--> 64
+    def("applyMapping", registerConverters(&pythonApplyMapping<1, npy_uint32, npy_uint32>), (arg("src"), arg("mapping"), arg("allow_incomplete_mapping")=false, arg("out")=python::object()));
+    def("applyMapping", registerConverters(&pythonApplyMapping<1, npy_uint64, npy_uint64>), (arg("src"), arg("mapping"), arg("allow_incomplete_mapping")=false, arg("out")=python::object()));
+    def("applyMapping", registerConverters(&pythonApplyMapping<1, npy_uint8, npy_uint8>),   (arg("src"), arg("mapping"), arg("allow_incomplete_mapping")=false, arg("out")=python::object()));
+
+    // 8 <--> 32
+    def("applyMapping", registerConverters(&pythonApplyMapping<1, npy_uint8, npy_uint32>), (arg("src"), arg("mapping"), arg("allow_incomplete_mapping")=false, arg("out")=python::object()));
+    def("applyMapping", registerConverters(&pythonApplyMapping<1, npy_uint32, npy_uint8>), (arg("src"), arg("mapping"), arg("allow_incomplete_mapping")=false, arg("out")=python::object()));
+
+    // 32 <--> 64
+    def("applyMapping", registerConverters(&pythonApplyMapping<1, npy_uint32, npy_uint64>), (arg("src"), arg("mapping"), arg("allow_incomplete_mapping")=false, arg("out")=python::object()));
+    def("applyMapping", registerConverters(&pythonApplyMapping<1, npy_uint64, npy_uint32>), (arg("src"), arg("mapping"), arg("allow_incomplete_mapping")=false, arg("out")=python::object()));
+
+    // 8 <--> 64
+    def("applyMapping", registerConverters(&pythonApplyMapping<1, npy_uint8, npy_uint64>), (arg("src"), arg("mapping"), arg("allow_incomplete_mapping")=false, arg("out")=python::object()));
+    def("applyMapping", registerConverters(&pythonApplyMapping<1, npy_uint64, npy_uint8>), (arg("src"), arg("mapping"), arg("allow_incomplete_mapping")=false, arg("out")=python::object()));
+
 }
 
 void defineEdgedetection();

--- a/vigranumpy/test/CMakeLists.txt
+++ b/vigranumpy/test/CMakeLists.txt
@@ -10,6 +10,7 @@ SET(TEST_SCRIPTS
     test4.py
     test_color.py
     test_segmentation.py
+    test_multidef.py
     )
 
 # setup the file 'testsuccess.cxx' which will become out-of-date when the

--- a/vigranumpy/test/test_multidef.py
+++ b/vigranumpy/test/test_multidef.py
@@ -1,0 +1,582 @@
+#######################################################################
+#                                                                      
+#         Copyright 2015-2016 by Ullrich Koethe and Philip Schill      
+#                                                                      
+#    This file is part of the VIGRA computer vision library.           
+#    The VIGRA Website is                                              
+#        http://hci.iwr.uni-heidelberg.de/vigra/                       
+#    Please direct questions, bug reports, and contributions to        
+#        ullrich.koethe@iwr.uni-heidelberg.de    or                    
+#        vigra@informatik.uni-hamburg.de                               
+#                                                                      
+#    Permission is hereby granted, free of charge, to any person       
+#    obtaining a copy of this software and associated documentation    
+#    files (the "Software"), to deal in the Software without           
+#    restriction, including without limitation the rights to use,      
+#    copy, modify, merge, publish, distribute, sublicense, and/or      
+#    sell copies of the Software, and to permit persons to whom the    
+#    Software is furnished to do so, subject to the following          
+#    conditions:                                                       
+#                                                                      
+#    The above copyright notice and this permission notice shall be    
+#    included in all copies or substantial portions of the             
+#    Software.                                                         
+#                                                                      
+#    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND    
+#    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES   
+#    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND          
+#    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT       
+#    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,      
+#    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING      
+#    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR     
+#    OTHER DEALINGS IN THE SOFTWARE.                                   
+#                                                                      
+#######################################################################
+
+from __future__ import division, print_function
+import sys
+print("\nexecuting test file", __file__, file=sys.stderr)
+exec(compile(open('set_paths.py', "rb").read(), 'set_paths.py', 'exec'))
+
+from nose.tools import assert_equal, raises, assert_raises
+import vigra
+import numpy as np
+
+def checkAboutSame(i1,i2):
+    assert(i1.shape==i2.shape)
+    difference=np.sum(np.abs(i1-i2))/float(np.size(i1))
+    assert(difference<5)
+
+def checkEqual(i1, i2):
+    assert(i1.shape==i2.shape)
+    assert((i1==i2).all())
+
+def test_convexHull():
+    points = np.array([[0, 0], [2, 0], [2, 1], [0, 1], [1, 0.5]], dtype=np.float32)
+    res = np.array([[0, 0], [0, 1], [2, 1], [2, 0], [0, 0]], dtype=np.float32)
+    res = vigra.taggedView(res)
+    hull = vigra.geometry.convexHull(points)
+    checkAboutSame(hull, res)
+    hull = vigra.geometry.convexHull(vigra.taggedView(points))
+    checkAboutSame(res, hull)
+    assert_raises(ValueError, vigra.geometry.convexHull, points.transpose())
+    assert_raises(ValueError, vigra.geometry.convexHull, points.astype(np.uint8))
+    assert_raises(ValueError, vigra.geometry.convexHull, 0, "a")
+
+def test_convolveOneDimension():
+    im = np.array([[0, 0, 0, 0, 0],
+                   [0, 0, 1, 0, 0],
+                   [0, 0, 0, 0, 0]], dtype=np.float64)
+    imc = np.array([[0, 0, 0, 0, 0],
+                    [0, 1, 2, 3, 0],
+                    [0, 0, 0, 0, 0]], dtype=np.float64)
+    k = vigra.filters.explictKernel(-1, 1, np.array([1, 2, 3], dtype=np.float64))
+    res = vigra.filters.convolveOneDimension(im, 0, k)
+    checkAboutSame(res, imc)
+    assert_raises(ValueError, vigra.filters.convolveOneDimension, im)
+    assert_raises(ValueError, vigra.filters.convolveOneDimension, im, 0)
+    assert_raises(ValueError, vigra.filters.convolveOneDimension, im.astype(np.uint8), 0, k)
+    assert_raises(ValueError, vigra.filters.convolveOneDimension, [0, 1], 0, k)
+
+def test_convolve():
+    # Test convolve with a 2D kernel.
+    im = np.array([[0, 0, 0, 0, 0],
+                   [0, 0, 0, 0, 0],
+                   [0, 0, 1, 0, 0],
+                   [0, 0, 0, 0, 0],
+                   [0, 0, 0, 0, 0]], dtype=np.float64)
+    imc0 = np.array([[0, 0, 0, 0, 0],
+                     [0, 1, 2, 3, 0],
+                     [0, 4, 5, 6, 0],
+                     [0, 7, 8, 9, 0],
+                     [0, 0, 0, 0, 0]], dtype=np.float64)
+    k = vigra.filters.Kernel2D()
+    k.initExplicitly((-1, -1), (1, 1), np.array([[1, 2, 3],
+                                                 [4, 5, 6],
+                                                 [7, 8, 9]], dtype=np.float64))
+    res = vigra.filters.convolve(im, k)
+    checkAboutSame(res, imc0)
+    assert_raises(ValueError, vigra.filters.convolve, im)
+    assert_raises(ValueError, vigra.filters.convolve, im.astype(np.uint8), k)
+    assert_raises(ValueError, vigra.filters.convolve, [0, 1], k)
+
+    # Test convolve with a 1D kernel.
+    imc1 = np.array([[0, 0, 0, 0, 0],
+                     [0, 1, 2, 3, 0],
+                     [0, 2, 4, 6, 0],
+                     [0, 3, 6, 9, 0],
+                     [0, 0, 0, 0, 0]], dtype=np.float64)
+    k = vigra.filters.Kernel1D()
+    k.initExplicitly(-1, 1, np.array([1, 2, 3], dtype=np.float64))
+    res = vigra.filters.convolve(im, k)
+    checkAboutSame(res, imc1)
+
+    # Test convolve with two 1D kernels.
+    imc2 = np.array([[0, 0, 0, 0, 0],
+                     [0, 0.5, 1, 2, 0],
+                     [0, 1, 2, 4, 0],
+                     [0, 1.5, 3, 6, 0],
+                     [0, 0, 0, 0, 0]], dtype=np.float64)
+    k0 = vigra.filters.explictKernel(-1, 1, np.array([1, 2, 3], dtype=np.float64))
+    k1 = vigra.filters.explictKernel(-1, 1, np.array([0.5, 1, 2], dtype=np.float64))
+    res = vigra.filters.convolve(im, (k0, k1))
+    checkAboutSame(res, imc2)
+
+def test_gaussianSmoothing():
+    im = np.array([[0, 0, 0],
+                   [0, 1, 0],
+                   [0, 0, 0]], dtype=np.float64)
+    imc = np.array([[ 0.04532707,  0.16757448,  0.04532707],
+                    [ 0.16757448,  0.61952398,  0.16757448],
+                    [ 0.04532707,  0.16757448,  0.04532707]])
+    res = vigra.filters.gaussianSmoothing(im, 0.5)
+    checkAboutSame(res, imc)
+    assert_raises(ValueError, vigra.filters.gaussianSmoothing, im)
+    assert_raises(ValueError, vigra.filters.gaussianSmoothing, im.astype(np.int8), 0.5)
+
+def test_laplacianOfGaussian():
+    im = np.zeros((6, 5), dtype=np.float64)
+    im[2, 2] = 1
+    imc = np.array([[ 0.07002893,  0.08373281,  0.08667994,  0.08373281,  0.07002893],
+                    [ 0.08373281,  0.0174964 , -0.08323153,  0.0174964 ,  0.08373281],
+                    [ 0.08646211, -0.0837286 , -0.31618431, -0.0837286 ,  0.08646211],
+                    [ 0.07846283,  0.00859282, -0.09564048,  0.00859282,  0.07846283],
+                    [ 0.0352323 ,  0.04236348,  0.04414477,  0.04236348,  0.0352323 ],
+                    [ 0.01053995,  0.01780715,  0.0248179 ,  0.01780715,  0.01053995]])
+    res = vigra.filters.laplacianOfGaussian(im)
+    checkAboutSame(res, imc)
+    assert_raises(ValueError, vigra.filters.laplacianOfGaussian, im.astype(np.uint8))
+
+def test_gaussianDivergence():
+    im = np.zeros((5, 5, 2), dtype=np.float64)
+    im[2, 2] = [0, 1]
+    imc = np.array([[  0.,   2.47013247e-02,   5.96311195e-19, -2.47013247e-02,   0.],
+                    [  0.,   5.63656325e-02,   1.35525272e-18, -5.63656325e-02,   0.],
+                    [  0.,   9.12597369e-02,   2.16840434e-18, -9.12597369e-02,   0.],
+                    [  0.,   5.63656325e-02,   1.35525272e-18, -5.63656325e-02,   0.],
+                    [  0.,   2.47013247e-02,   5.96311195e-19, -2.47013247e-02,   0.]])
+    res = vigra.filters.gaussianDivergence(im)
+    checkAboutSame(res, imc)
+    assert_raises(ValueError, vigra.filters.gaussianDivergence, np.zeros((5, 6, 3), dtype=np.float64))
+    assert_raises(ValueError, vigra.filters.gaussianDivergence, np.zeros((10, 11, 12, 2), dtype=np.float64))
+
+def test_multiBinaryErosionDilation():
+    im = np.array([[0, 0, 0, 0, 0],
+                   [0, 1, 1, 0, 0],
+                   [0, 0, 1, 0, 0],
+                   [0, 0, 0, 0, 0]], dtype=np.uint8)
+    imc = np.array([[0, 1, 1, 0, 0],
+                    [1, 1, 1, 1, 0],
+                    [0, 1, 1, 1, 0],
+                    [0, 0, 1, 0, 0]], dtype=np.uint8)
+    imc2 = np.array([[1, 1, 1, 0, 0],
+                    [1, 1, 1, 1, 0],
+                    [0, 1, 1, 1, 0],
+                    [0, 0, 1, 0, 0]], dtype=np.uint8)
+    res = vigra.filters.multiBinaryErosion(imc, 1)
+    checkEqual(res, im)
+    assert_raises(ValueError, vigra.filters.multiBinaryErosion, imc)
+    assert_raises(ValueError, vigra.filters.multiBinaryErosion, imc.astype(np.float64))
+    res = vigra.filters.multiBinaryDilation(im, 1)
+    checkEqual(res, imc)
+    assert_raises(ValueError, vigra.filters.multiBinaryDilation, im)
+    assert_raises(ValueError, vigra.filters.multiBinaryDilation, im.astype(np.float64))
+
+    res = vigra.filters.multiBinaryOpening(im, 1)
+    checkEqual(res, np.zeros((4, 5), dtype=np.uint8))
+    res = vigra.filters.multiBinaryOpening(imc, 1)
+    checkEqual(res, imc)
+    assert_raises(ValueError, vigra.filters.multiBinaryOpening, im)
+    assert_raises(ValueError, vigra.filters.multiBinaryOpening, im.astype(np.float64))
+    res = vigra.filters.multiBinaryClosing(im, 1)
+    checkEqual(res, im)
+    res = vigra.filters.multiBinaryClosing(imc, 1)
+    checkEqual(res, imc2)
+    assert_raises(ValueError, vigra.filters.multiBinaryClosing, im)
+    assert_raises(ValueError, vigra.filters.multiBinaryClosing, im.astype(np.float64))
+
+def test_multiGrayscaleErosionDilation():
+    im = np.array([[0, 0, 0, 0, 0],
+                   [0, 128, 100, 0, 0],
+                   [0, 0, 128, 0, 0],
+                   [0, 0, 0, 0, 0]], dtype=np.uint8)
+    imc0 = np.array([[0, 0, 0, 0, 0],
+                     [0, 81, 81, 0, 0],
+                     [0, 0, 81, 0, 0],
+                     [0, 0, 0, 0, 0]], dtype=np.uint8)
+    imc1 = np.array([[ 56,  92,  64,  28,   0],
+                     [ 92, 128, 100,  64,   0],
+                     [ 56,  92, 128,  92,   0],
+                     [  0,  56,  92,  56,   0]], dtype=np.uint8)
+    imc2 = np.array([[0, 47, 19, 0, 0],
+                     [47, 128, 100, 19, 0],
+                     [0, 47, 128, 47, 0],
+                     [0, 0, 47, 0, 0]], dtype=np.uint8)
+    res = vigra.filters.multiGrayscaleErosion(im, 9)
+    checkEqual(res, imc0)
+    assert_raises(ValueError, vigra.filters.multiGrayscaleErosion, im)
+    assert_raises(ValueError, vigra.filters.multiGrayscaleErosion, im.astype(np.int16), 9)
+    res = vigra.filters.multiGrayscaleDilation(im, 6)
+    checkEqual(res, imc1)
+    assert_raises(ValueError, vigra.filters.multiGrayscaleDilation, im)
+    assert_raises(ValueError, vigra.filters.multiGrayscaleDilation, im.astype(np.int16), 6)
+
+    res = vigra.filters.multiGrayscaleOpening(im, 9)
+    checkEqual(res, imc0)
+    assert_raises(ValueError, vigra.filters.multiGrayscaleOpening, im)
+    assert_raises(ValueError, vigra.filters.multiGrayscaleOpening, im.astype(np.int16), 9)
+    res = vigra.filters.multiGrayscaleClosing(im, 9)
+    checkEqual(res, imc2)
+    assert_raises(ValueError, vigra.filters.multiGrayscaleClosing, im)
+    assert_raises(ValueError, vigra.filters.multiGrayscaleClosing, im.astype(np.int16), 9)
+
+def test_distanceTransform():
+    # Test distanceTransform and distanceTransform2D.
+    im = np.array([[0, 0, 0, 0, 0],
+                   [0, 1, 1, 0, 0],
+                   [0, 0, 1, 0, 0],
+                   [0, 0, 0, 0, 0]], dtype=np.uint32)
+    s2 = 1.41421354
+    s5 = 2.23606801
+    imd = np.array([[s2, 1, 1, s2, s5],
+                    [1, 0, 0, 1, 2],
+                    [s2, 1, 0, 1, 2],
+                    [s5, s2, 1, s2, s5]], dtype=np.float32)
+    res = vigra.filters.distanceTransform(im)
+    checkAboutSame(res, imd)
+    assert_raises(ValueError, vigra.filters.distanceTransform, np.zeros((5, 6, 7, 8), dtype=np.float32))
+
+    # Test vectorDistanceTransform.
+    im = im.astype(np.float32)
+    imd = np.array([[[1, 1], [1, 0], [1, 0], [1, -1], [1, -2]],
+                    [[0, 1], [0, 0], [0, 0], [0, -1], [0, -2]],
+                    [[-1, 1], [0, 1], [0, 0], [0, -1], [0, -2]],
+                    [[-1, 2], [-1, 1], [-1, 0], [-1, -1], [-1, -2]]], dtype=np.float32)
+    res = vigra.filters.vectorDistanceTransform(im)
+    checkAboutSame(res, imd)
+    assert_raises(ValueError, vigra.filters.vectorDistanceTransform, np.zeros((5, 6, 7, 8), dtype=np.float32))
+    
+def test_boundaryDistanceTransform():
+    # Test boundaryDistanceTransform.
+    im = np.array([[2, 2, 2, 2, 2, 2],
+                   [2, 2, 2, 2, 2, 2],
+                   [1, 1, 1, 1, 2, 2],
+                   [1, 1, 1, 1, 1, 2],
+                   [1, 1, 1, 1, 1, 1],
+                   [1, 1, 1, 1, 1, 1]], dtype=np.float32)
+    s2 = 0.91421354
+    s3 = 1.73606801
+    s5 = 2.32842708
+    s6 = 3.10555124
+    imd = np.array([[1.5, 1.5, 1.5, 1.5, s3, s5],
+                    [0.5, 0.5, 0.5, 0.5, s2, s3],
+                    [0.5, 0.5, 0.5, 0.5, 0.5, s2],
+                    [1.5, 1.5, 1.5, s2, 0.5, 0.5],
+                    [2.5, 2.5, s5, s3, s2, 0.5],
+                    [3.5, 3.5, s6, s5, s3, 1.5]], dtype=np.float32)
+    res = vigra.filters.boundaryDistanceTransform(im)
+    checkAboutSame(res, imd)
+    assert_raises(ValueError, vigra.filters.boundaryDistanceTransform, im.astype(np.uint8))
+    assert_raises(ValueError, vigra.filters.boundaryDistanceTransform, np.zeros((5, 6, 7, 8), dtype=np.float32))
+
+    # Test boundaryVectorDistanceTransform.
+    imd2 = np.array([[[ 1.5,  0. ], [ 1.5,  0. ], [ 1.5,  0. ], [ 1.5,  0. ], [ 1.5, -1. ], [ 1.5, -2. ]],
+                     [[ 0.5,  0. ], [ 0.5,  0. ], [ 0.5,  0. ], [ 0.5,  0. ], [ 0.5, -1. ], [ 1. , -1.5]],
+                     [[-0.5,  0. ], [-0.5,  0. ], [-0.5,  0. ], [-0.5,  0. ], [ 0. , -0.5], [ 0.5, -1. ]],
+                     [[-1.5,  0. ], [-1.5,  0. ], [-1.5,  0. ], [-1. ,  0.5], [-0.5,  0. ], [ 0. , -0.5]],
+                     [[-2.5,  0. ], [-2.5,  0. ], [-2. ,  1.5], [-1.5,  1. ], [-1. ,  0.5], [-0.5,  0. ]],
+                     [[-3.5,  0. ], [-3.5,  0. ], [-2.5,  2. ], [-2. ,  1.5], [-1.5,  1. ], [-1.5,  0. ]]],
+                    dtype=np.float32)
+    res = vigra.filters.boundaryVectorDistanceTransform(im)
+    checkAboutSame(res, imd2)
+    assert_raises(ValueError, vigra.filters.boundaryVectorDistanceTransform, im.astype(np.uint8))
+    assert_raises(ValueError, vigra.filters.boundaryVectorDistanceTransform, np.zeros((5, 6, 7, 8), dtype=np.float32))
+
+def test_eccentricityTransform():
+    # Test eccentricityTransform.
+    im = np.array([[2, 2, 2, 3, 3, 3, 3],
+                   [2, 1, 1, 1, 1, 1, 3],
+                   [2, 1, 1, 1, 1, 1, 3],
+                   [2, 1, 1, 1, 1, 1, 3],
+                   [2, 2, 2, 3, 3, 3, 3]], dtype=np.float32)
+    s2 = 1.41421354
+    imd = np.array([[2, s2+1, s2+2, s2+3, s2+2, s2+1, 2],
+                    [1, s2+1, s2, 1, s2, s2+1, 1],
+                    [0, 2, 1, 0, 1, 2, 0],
+                    [1, s2+1, s2, 1, s2, s2+1, 1],
+                    [2, s2+1, s2+2, s2+3, s2+2, s2+1, 2]])
+    res = vigra.filters.eccentricityTransform(im)
+    checkAboutSame(res, imd)
+    assert_raises(ValueError, vigra.filters.eccentricityTransform, im.astype(np.int32))
+    assert_raises(ValueError, vigra.filters.eccentricityTransform, np.zeros((5, 6, 7, 8), dtype=np.float32))
+
+    # Test eccentricityCenters.
+    c = vigra.filters.eccentricityCenters(im)
+    assert(c[1] == (2, 3) and c[2] == (2, 0) and c[3] == (2, 6))
+    assert_raises(ValueError, vigra.filters.eccentricityCenters, im.astype(np.int32))
+    assert_raises(ValueError, vigra.filters.eccentricityCenters, np.zeros((5, 6, 7, 8), dtype=np.float32))
+    
+    # Test eccentricityTransformWithCenters.
+    res, c = vigra.filters.eccentricityTransformWithCenters(im)
+    checkAboutSame(res, imd)
+    assert(c[1] == (2, 3) and c[2] == (2, 0) and c[3] == (2, 6))
+    assert_raises(ValueError, vigra.filters.eccentricityTransformWithCenters, im.astype(np.int32))
+    assert_raises(ValueError, vigra.filters.eccentricityTransformWithCenters, np.zeros((5, 6, 7, 8), dtype=np.float32))
+
+def test_gaussianGradient():
+    im = np.array([[0, 0, 0, 0, 0],
+                   [0, 1, 1, 0, 0],
+                   [0, 1, 1, 1, 0],
+                   [0, 0, 1, 1, 0],
+                   [0, 0, 0, 0, 0]], dtype=np.float64)
+    imd0 = np.array([[[ -8.01406117e-18 ,  8.02309608e-18],
+                     [ -9.18662066e-18 ,  8.61150404e-02],
+                     [ -7.83858551e-18 , -1.21313252e-01],
+                     [ -2.95644367e-18 , -1.88750139e-01],
+                     [ -5.94896474e-19 ,  0.00000000e+00]],
+                    [[  8.61150404e-02 , -1.30104261e-17],
+                     [  1.29233242e-01 ,  1.29233242e-01],
+                     [  2.03991002e-01 , -1.01871715e-01],
+                     [  2.15420146e-01 , -2.15420146e-01],
+                     [  1.88750139e-01 ,  1.73472348e-18]],
+                    [[ -1.21313252e-01 , -1.73472348e-18],
+                     [ -1.01871715e-01 ,  2.03991002e-01],
+                     [  2.77555756e-17 , -2.58040117e-17],
+                     [  1.01871715e-01 , -2.03991002e-01],
+                     [  1.21313252e-01 , -2.94902991e-17]],
+                    [[ -1.88750139e-01 , -1.38777878e-17],
+                     [ -2.15420146e-01 ,  2.15420146e-01],
+                     [ -2.03991002e-01 ,  1.01871715e-01],
+                     [ -1.29233242e-01 , -1.29233242e-01],
+                     [ -8.61150404e-02 ,  8.67361738e-19]],
+                    [[ -5.94896474e-19 ,  0.00000000e+00],
+                     [ -2.95644367e-18 ,  1.88750139e-01],
+                     [ -7.83858551e-18 ,  1.21313252e-01],
+                     [ -9.18662066e-18 , -8.61150404e-02],
+                     [ -8.01406117e-18 ,  8.02309608e-18]]], dtype=np.float64)
+    imd1 = np.array([[  1.13399844e-17 , 8.61150404e-02 , 1.21313252e-01 , 1.88750139e-01 , 5.94896474e-19],
+                     [  8.61150404e-02 , 1.82763404e-01 , 2.28013542e-01 , 3.04650092e-01 , 1.88750139e-01],
+                     [  1.21313252e-01 , 2.28013542e-01 , 3.78974801e-17 , 2.28013542e-01 , 1.21313252e-01],
+                     [  1.88750139e-01 , 3.04650092e-01 , 2.28013542e-01 , 1.82763404e-01 , 8.61150404e-02],
+                     [  5.94896474e-19 , 1.88750139e-01 , 1.21313252e-01 , 8.61150404e-02 , 1.13399844e-17]], dtype=np.float64)
+    res = vigra.filters.gaussianGradient(im, 1)
+    checkAboutSame(res, imd0)
+    assert_raises(ValueError, vigra.filters.gaussianGradient, im)
+    assert_raises(ValueError, vigra.filters.gaussianGradient, im.astype(np.uint8), 1)
+    assert_raises(ValueError, vigra.filters.gaussianGradient, np.zeros((5, 6, 7, 8, 9), dtype=np.float64), 1)
+
+    res = vigra.filters.gaussianGradientMagnitude(im, 1)
+    checkAboutSame(res, imd1)
+    assert_raises(ValueError, vigra.filters.gaussianGradientMagnitude, im)
+    assert_raises(ValueError, vigra.filters.gaussianGradientMagnitude, im.astype(np.uint8), 1)
+    assert_raises(ValueError, vigra.filters.gaussianGradientMagnitude, np.zeros((5, 6, 7, 8, 9, 10), dtype=np.float64), 1)
+
+def test_hessianOfGaussian():
+    im = np.array([[0, 0, 0, 0, 0],
+                   [0, 1, 1, 0, 0],
+                   [0, 1, 1, 1, 0],
+                   [0, 0, 1, 1, 0],
+                   [0, 0, 0, 0, 0]], dtype=np.float64)
+    imd = np.array([[[  2.03117070e-01,  4.84491752e-34,  2.03117070e-01],
+                     [  2.65611971e-01, -1.09103007e-18, -9.96424231e-02],
+                     [  3.34984252e-01,  3.98564636e-18, -2.12308959e-01],
+                     [  2.93927033e-01,  4.46302120e-18,  9.19749106e-02],
+                     [  2.36835873e-01, -2.40741243e-35,  2.36835873e-01]],
+                    [[ -9.96424231e-02,  3.46944695e-18,  2.65611971e-01],
+                     [ -8.92026671e-02,  7.56238735e-02, -8.92026671e-02],
+                     [ -1.41639200e-02,  5.51365585e-02, -2.62273105e-01],
+                     [  7.17062698e-02, -2.89764871e-02,  7.17062698e-02],
+                     [  9.19749106e-02,  7.80625564e-18,  2.93927033e-01]],
+                    [[ -2.12308959e-01,  0.00000000e+00,  3.34984252e-01],
+                     [ -2.62273105e-01,  5.51365585e-02, -1.41639200e-02],
+                     [ -3.06656412e-01,  1.30341282e-01, -3.06656412e-01],
+                     [ -2.62273105e-01,  5.51365585e-02, -1.41639200e-02],
+                     [ -2.12308959e-01, -2.60208521e-18,  3.34984252e-01]],
+                    [[  9.19749106e-02, -7.58941521e-18,  2.93927033e-01],
+                     [  7.17062698e-02, -2.89764871e-02,  7.17062698e-02],
+                     [ -1.41639200e-02,  5.51365585e-02, -2.62273105e-01],
+                     [ -8.92026671e-02,  7.56238735e-02, -8.92026671e-02],
+                     [ -9.96424231e-02,  0.00000000e+00,  2.65611971e-01]],
+                    [[  2.36835873e-01, -2.40741243e-35,  2.36835873e-01],
+                     [  2.93927033e-01, -4.46302120e-18,  9.19749106e-02],
+                     [  3.34984252e-01, -3.98564636e-18, -2.12308959e-01],
+                     [  2.65611971e-01,  1.09103007e-18, -9.96424231e-02],
+                     [  2.03117070e-01,  4.84491752e-34,  2.03117070e-01]]], dtype=np.float64)
+    res = vigra.filters.hessianOfGaussian(im, 1)
+    checkAboutSame(res, imd)
+    assert_raises(ValueError, vigra.filters.hessianOfGaussian, im)
+    assert_raises(ValueError, vigra.filters.hessianOfGaussian, im.astype(np.uint8), 1)
+    assert_raises(ValueError, vigra.filters.hessianOfGaussian, np.zeros((5, 6, 7, 8, 9), dtype=np.float32), 1)
+
+def test_structureTensor():
+    im = np.array([[0, 0, 0],
+                   [0, 1, 1]], dtype=np.float64)
+    imd = np.array([[[0, 0, 0.00163116],
+                     [0, 0, 0.01856249],
+                     [0, 0, 0.00163116]],
+                    [[0, 0, 0.01856249],
+                     [0, 0, 0.21124014],
+                     [0, 0, 0.01856249]]], dtype=np.float64)
+    res = vigra.filters.structureTensor(im, 0.2, 0.4)
+    checkAboutSame(imd, res)
+    assert_raises(ValueError, vigra.filters.structureTensor, im)
+    assert_raises(ValueError, vigra.filters.structureTensor, im, 0.2)
+    assert_raises(ValueError, vigra.filters.structureTensor, im.astype(np.uint8), 0.2, 0.4)
+    assert_raises(ValueError, vigra.filters.structureTensor, np.zeros((5, 6, 7, 8, 9, 10), dtype=np.float64), 0.5, 0.75)
+
+def test_vectorToTensor():
+    im = np.zeros((2, 3, 2), dtype=np.float32)
+    im[0, 1] = [4, 5]
+    im[1, 1] = [3, 7]
+    imd = np.array([[[0, 0, 0],
+                     [16, 20, 25],
+                     [0, 0, 0]],
+                    [[0, 0, 0],
+                     [9, 21, 49],
+                     [0, 0, 0]]], dtype=np.float32)
+    res = vigra.filters.vectorToTensor(im)
+    checkAboutSame(res, imd)
+    vigra.filters.vectorToTensor(np.zeros((3, 4, 5, 3), dtype=np.float32))
+    assert_raises(ValueError, vigra.filters.vectorToTensor, im.astype(np.uint32))
+    assert_raises(ValueError, vigra.filters.vectorToTensor, np.zeros((2, 3, 4), dtype=np.float32))
+    assert_raises(ValueError, vigra.filters.vectorToTensor, np.zeros((3, 4, 5, 4), dtype=np.float32))
+
+def test_tensorTraceDetEigen():
+    # Test tensorTrace.
+    im = np.array([[0, 0, 0],
+                   [0, 1, 1]], dtype=np.float64)
+    im = vigra.filters.structureTensor(im, 0.2, 0.4)
+    imd = np.array([[ 0.00163116,  0.01856249,  0.00163116],
+                    [ 0.01856249,  0.21124014,  0.01856249]], dtype=np.float64)
+    res = vigra.filters.tensorTrace(im)
+    checkAboutSame(res, imd)
+    assert_raises(ValueError, vigra.filters.tensorTrace, im.astype(np.uint32))
+    assert_raises(ValueError, vigra.filters.tensorTrace, np.zeros((3, 4, 5), dtype=np.float64))
+
+    # Test tensorDeterminant.
+    vigra.filters.tensorDeterminant(im)
+    assert_raises(ValueError, vigra.filters.tensorDeterminant, im.astype(np.uint32))
+    assert_raises(ValueError, vigra.filters.tensorDeterminant, np.zeros((3, 4, 5), dtype=np.float64))
+
+    # Test tensorEigenvalues.
+    imd = np.array([[[ 0.00163116, 0 ],
+                     [ 0.01856249, 0 ],
+                     [ 0.00163116, 0 ]],
+                    [[ 0.01856249, 0 ],
+                     [ 0.21124014, 0 ],
+                     [ 0.01856249, 0 ]]], dtype=np.float64)
+    res = vigra.filters.tensorEigenvalues(im)
+    checkAboutSame(res, imd)
+    assert_raises(ValueError, vigra.filters.tensorEigenvalues, im.astype(np.uint32))
+    assert_raises(ValueError, vigra.filters.tensorEigenvalues, np.zeros((3, 4, 5), dtype=np.float64))
+
+def test_applyColortable():
+    vigra.colors.applyColortable(np.zeros((10, 11), dtype=np.uint8), np.zeros((10, 4), dtype=np.uint8))
+    assert_raises(ValueError, vigra.colors.applyColortable, np.zeros((10, 11), dtype=np.uint8))
+    assert_raises(ValueError, vigra.colors.applyColortable, np.zeros((10, 11), dtype=np.uint8), np.zeros((10, 4), dtype=np.uint32))
+    assert_raises(ValueError, vigra.colors.applyColortable, np.zeros((10, 11, 12), dtype=np.uint8), np.zeros((10, 4), dtype=np.uint8))
+
+def test_linearRangeMapping():
+    im = np.zeros((10, 11), dtype=np.uint8)
+    im[5, 5] = 128
+    vigra.colors.linearRangeMapping(im)
+    im = np.zeros((10, 11, 12, 13), dtype=np.uint8)
+    im[5, 5, 5, 6] = 128
+    assert_raises(ValueError, vigra.colors.linearRangeMapping, im)
+
+def test_labelImage():
+    im = np.array([[1, 1, 2, 2],
+                   [1, 0, 2, 2],
+                   [0, 0, 1, 1]], dtype=np.uint8)
+    imd0 = np.array([[1, 1, 3, 3],
+                    [1, 2, 3, 3],
+                    [2, 2, 4, 4]], dtype=np.uint8)
+    imd1 = np.array([[1, 1, 2, 2],
+                     [1, 0, 2, 2],
+                     [0, 0, 3, 3]], dtype=np.uint8)
+    res = vigra.analysis.labelImage(im)
+    checkEqual(res, imd0)
+    vigra.analysis.labelImage(im, "direct")
+    assert_raises(ValueError, vigra.analysis.labelImage, im.astype(np.float64))
+    assert_raises(ValueError, vigra.analysis.labelImage, np.zeros((3, 4, 5), dtype=np.uint8))
+    res = vigra.analysis.labelImageWithBackground(im)
+    checkEqual(res, imd1)
+    vigra.analysis.labelImageWithBackground(im, "direct")
+    assert_raises(ValueError, vigra.analysis.labelImageWithBackground, im.astype(np.float64))
+    assert_raises(ValueError, vigra.analysis.labelImageWithBackground, np.zeros((3, 4, 5), dtype=np.uint8))
+
+def test_labelVolume():
+    im = np.zeros((4, 5, 6), dtype=np.uint8)
+    vigra.analysis.labelVolume(im)
+    vigra.analysis.labelVolume(im, "direct")
+    assert_raises(ValueError, vigra.analysis.labelVolume, im.astype(np.float64))
+    assert_raises(ValueError, vigra.analysis.labelVolume, np.zeros((3, 4, 5, 6), dtype=np.uint8))
+    vigra.analysis.labelVolumeWithBackground(im)
+    vigra.analysis.labelVolumeWithBackground(im, "direct")
+    assert_raises(ValueError, vigra.analysis.labelVolumeWithBackground, im.astype(np.float64))
+    assert_raises(ValueError, vigra.analysis.labelVolumeWithBackground, np.zeros((3, 4, 5, 6), dtype=np.uint8))
+
+def test_labelMultiArray():
+    im = np.zeros((4, 5, 6, 7), dtype=np.uint8)
+    vigra.analysis.labelMultiArray(im)
+    vigra.analysis.labelMultiArray(im, "direct")
+    assert_raises(ValueError, vigra.analysis.labelMultiArray, im, "direct", 0)
+    assert_raises(ValueError, vigra.analysis.labelMultiArray, im.astype(np.float64))
+    vigra.analysis.labelMultiArrayWithBackground(im)
+    vigra.analysis.labelMultiArrayWithBackground(im, "direct")
+    vigra.analysis.labelMultiArrayWithBackground(im, "direct", 0)
+    assert_raises(ValueError, vigra.analysis.labelMultiArrayWithBackground, im, "direct", 0, 1)
+    assert_raises(ValueError, vigra.analysis.labelMultiArrayWithBackground, im.astype(np.float64))
+
+def test_extendedLocalMinima():
+    im = np.array([[5, 4, 5, 6],
+                   [6, 3, 4, 5],
+                   [7, 4, 5, 6]], dtype=np.uint8)
+    imd = np.array([[0, 0, 0, 0],
+                    [0, 1, 0, 0],
+                    [0, 0, 0, 0]], dtype=np.uint8)
+    res = vigra.analysis.extendedLocalMinima(im, 1)
+    checkEqual(res, imd)
+    vigra.analysis.extendedLocalMinima(im, 1, 8)
+    vigra.analysis.extendedLocalMinima(im.astype(np.float32))
+    vigra.analysis.extendedLocalMinima(im.astype(np.float32), 1.5)
+    assert_raises(ValueError, vigra.analysis.extendedLocalMinima, im)
+    assert_raises(ValueError, vigra.analysis.extendedLocalMinima, im, 1, 8, 1)
+    assert_raises(ValueError, vigra.analysis.extendedLocalMinima, im, 1.0)
+
+def test_extendedLocalMinima3D():
+    im = np.zeros((3, 4, 5), dtype=np.uint8)
+    vigra.analysis.extendedLocalMinima3D(im)
+    vigra.analysis.extendedLocalMinima3D(im, 5)
+    vigra.analysis.extendedLocalMinima3D(im, 5, 6)
+    assert_raises(ValueError, vigra.analysis.extendedLocalMinima3D, im, 1.5)
+    assert_raises(ValueError, vigra.analysis.extendedLocalMinima3D, im, 5, 6, 1)
+
+def test_watersheds():
+    im_f = vigra.arraytypes.ScalarImage(np.random.rand(100, 200)*255, dtype=np.float32)
+    im_i = vigra.arraytypes.ScalarImage(np.random.rand(100, 200)*255, dtype=np.uint32)
+
+    vigra.analysis.watersheds(im_f)
+    vigra.analysis.watersheds(im_f, seeds=im_i)
+    vigra.analysis.watersheds(im_f, method="RegionGrowing")
+    vigra.analysis.watersheds(im_f, seeds=im_i, method="RegionGrowing")
+    assert_raises(ValueError, vigra.analysis.watersheds, im_f, seeds=im_i.astype(np.float32), method="RegionGrowing")
+    assert_raises(ValueError, vigra.analysis.watersheds, im_f, seeds=np.zeros((100, 200, 3), dtype=np.uint32), method="RegionGrowing")
+    assert_raises(ValueError, vigra.analysis.watersheds, np.zeros((100, 200, 3), dtype=np.float32), seeds=np.zeros((100, 200), dtype=np.uint32), method="RegionGrowing")
+
+    vigra.analysis.watershedsNew(im_f)
+    vigra.analysis.watershedsNew(im_f, seeds=im_i)
+    vigra.analysis.watershedsNew(im_f, method="RegionGrowing")
+    vigra.analysis.watershedsNew(im_f, seeds=im_i, method="RegionGrowing")
+    assert_raises(ValueError, vigra.analysis.watershedsNew, im_f, seeds=im_i.astype(np.float32), method="RegionGrowing")
+    assert_raises(ValueError, vigra.analysis.watershedsNew, im_f, seeds=np.zeros((100, 200, 3), dtype=np.uint32), method="RegionGrowing")
+    assert_raises(ValueError, vigra.analysis.watershedsNew, np.zeros((100, 200, 3), dtype=np.float32), seeds=np.zeros((100, 200), dtype=np.uint32), method="RegionGrowing")
+
+def test_superpixels():
+    im_f = vigra.arraytypes.ScalarImage(np.random.rand(100, 200)*255, dtype=np.float32)
+    im_i = vigra.arraytypes.ScalarImage(np.random.rand(100, 200)*255, dtype=np.uint32)
+
+    vigra.analysis.slicSuperpixels(im_f, 0.5, 1)
+    assert_raises(ValueError, vigra.analysis.slicSuperpixels, im_f)
+    assert_raises(ValueError, vigra.analysis.slicSuperpixels, im_f, 0.5)
+    assert_raises(ValueError, vigra.analysis.slicSuperpixels, np.zeros((100, 200, 10, 20), dtype=np.float32), 0.5, 1)


### PR DESCRIPTION
Includes some build fixes for Mac that change how brew is used. In particular, this tries to avoid uninstalling any packages that could be useful. Also, it skips updating brew so that packages like Boost don't have to be downloaded and installed (one of the longer ones). Finally, cleans up a bunch build intermediates on Mac and Linux to hopefully improve memory usage. This appears to cut down the build time to ~35min for the Mac builds. 