### PR TITLE
Travis Mac Build fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,8 @@ before_script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install $(echo -e $BREW_DEPS) || true                                          ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ ${TRAVIS_PYTHON_VERSION:0:1} -eq 3 ]]; then sudo ln -s /usr/local/bin/pip3 /usr/local/bin/pip ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ ${TRAVIS_PYTHON_VERSION:0:1} -eq 3 ]]; then sudo ln -s /usr/local/bin/python3 /usr/local/bin/python ; fi
+  - if [[ "$TRAVIS_PYTHON_VERSION" == "3.2" ]]; then pip install --upgrade 'pip<8' 'setuptools<19'                                ; fi
+  - if [[ "$TRAVIS_PYTHON_VERSION" != "3.2" ]]; then pip install --upgrade pip setuptools                                         ; fi
   - pip install nose
   - pip install numpy
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ ${TRAVIS_PYTHON_VERSION:0:1} -eq 2 ]]; then brew install boost-python --with-python ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,11 @@ matrix:
     - os: osx
       osx_image: xcode7.3
       language: generic
-      env: TRAVIS_PYTHON_VERSION="2" BREW_DEPS="cmake\nhdf5\nboost\nlibjpeg\nlibtiff\nlibpng\nfftw\nreadline"
+      env: TRAVIS_PYTHON_VERSION="2" BREW_DEPS="cmake\nhdf5\nboost\nlibjpeg\nlibtiff\nlibpng\nfftw\nreadline\npython"
     - os: osx
       osx_image: xcode7.3
       language: generic
-      env: TRAVIS_PYTHON_VERSION="3" BREW_DEPS="cmake\nhdf5\nboost\nlibjpeg\nlibtiff\nlibpng\nfftw\nreadline"
+      env: TRAVIS_PYTHON_VERSION="3" BREW_DEPS="cmake\nhdf5\nboost\nlibjpeg\nlibtiff\nlibpng\nfftw\nreadline\npython3"
 
 
 addons:
@@ -48,8 +48,6 @@ before_script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew remove --force $(grep -v -F -x -f <(cat <(brew deps --skip-optional --union $(echo -e $BREW_DEPS)) <(echo -e $BREW_DEPS))  <(cat <(brew leaves) <(brew deps --skip-optional --union $(brew leaves)))); brew cleanup --force ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew upgrade --cleanup $(echo -e $BREW_DEPS) || true                                ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install $(echo -e $BREW_DEPS) || true                                          ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ ${TRAVIS_PYTHON_VERSION:0:1} -eq 2 ]]; then brew install python                     ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ ${TRAVIS_PYTHON_VERSION:0:1} -eq 3 ]]; then brew install python3                    ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ ${TRAVIS_PYTHON_VERSION:0:1} -eq 3 ]]; then sudo ln -s /usr/local/bin/pip3 /usr/local/bin/pip ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ ${TRAVIS_PYTHON_VERSION:0:1} -eq 3 ]]; then sudo ln -s /usr/local/bin/python3 /usr/local/bin/python ; fi
   - pip install nose

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,10 +43,8 @@ addons:
 
 before_script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PATH="/usr/local/bin:${PATH}"                                                ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then travis_retry brew update                                                            ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew tap homebrew/science                                                           ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew remove --force $(grep -v -F -x -f <(cat <(brew deps --skip-optional --union $(echo -e $BREW_DEPS)) <(echo -e $BREW_DEPS))  <(cat <(brew leaves) <(brew deps --skip-optional --union $(brew leaves)))); brew cleanup --force ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew upgrade --cleanup $(echo -e $BREW_DEPS) || true                                ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install $(echo -e $BREW_DEPS) || true                                          ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ ${TRAVIS_PYTHON_VERSION:0:1} -eq 3 ]]; then sudo ln -s /usr/local/bin/pip3 /usr/local/bin/pip ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ ${TRAVIS_PYTHON_VERSION:0:1} -eq 3 ]]; then sudo ln -s /usr/local/bin/python3 /usr/local/bin/python ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,10 +43,11 @@ addons:
 
 before_script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PATH="/usr/local/bin:${PATH}"                                                ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew remove --force $(brew list); brew cleanup --force                              ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then travis_retry brew update                                                            ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew tap homebrew/science                                                           ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install $(echo -e $BREW_DEPS)                                                  ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew remove --force $(grep -v -F -x -f <(cat <(brew deps --skip-optional --union $(echo -e $BREW_DEPS)) <(echo -e $BREW_DEPS))  <(cat <(brew leaves) <(brew deps --skip-optional --union $(brew leaves)))); brew cleanup --force ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew upgrade --cleanup $(echo -e $BREW_DEPS) || true                                ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install $(echo -e $BREW_DEPS) || true                                          ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ ${TRAVIS_PYTHON_VERSION:0:1} -eq 2 ]]; then brew install python                     ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ ${TRAVIS_PYTHON_VERSION:0:1} -eq 3 ]]; then brew install python3                    ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ ${TRAVIS_PYTHON_VERSION:0:1} -eq 3 ]]; then sudo ln -s /usr/local/bin/pip3 /usr/local/bin/pip ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,11 @@ matrix:
     - os: osx
       osx_image: xcode7.3
       language: generic
-      env: TRAVIS_PYTHON_VERSION="2"
+      env: TRAVIS_PYTHON_VERSION="2" BREW_DEPS="cmake\nhdf5\nboost\nlibjpeg\nlibtiff\nlibpng\nfftw\nreadline"
     - os: osx
       osx_image: xcode7.3
       language: generic
-      env: TRAVIS_PYTHON_VERSION="3"
+      env: TRAVIS_PYTHON_VERSION="3" BREW_DEPS="cmake\nhdf5\nboost\nlibjpeg\nlibtiff\nlibpng\nfftw\nreadline"
 
 
 addons:
@@ -46,14 +46,7 @@ before_script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew remove --force $(brew list); brew cleanup --force                              ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then travis_retry brew update                                                            ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew tap homebrew/science                                                           ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install cmake                                                                  ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install hdf5                                                                   ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install boost                                                                  ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install libjpeg                                                                ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install libtiff                                                                ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install libpng                                                                 ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install fftw                                                                   ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install readline                                                               ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install $(echo -e $BREW_DEPS)                                                  ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ ${TRAVIS_PYTHON_VERSION:0:1} -eq 2 ]]; then brew install python                     ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ ${TRAVIS_PYTHON_VERSION:0:1} -eq 3 ]]; then brew install python3                    ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ ${TRAVIS_PYTHON_VERSION:0:1} -eq 3 ]]; then sudo ln -s /usr/local/bin/pip3 /usr/local/bin/pip ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,4 +68,5 @@ script:
   - mkdir build && cd build
   - cmake -DCMAKE_BUILD_TYPE=Release -DTEST_VIGRANUMPY=1 -DDEPENDENCY_SEARCH_PREFIX=$VIRTUAL_ENV -DAUTOBUILD_TESTS=1 -DAUTOEXEC_TESTS=0 -DWITH_BOOST_THREAD=$WITH_BOOST_THREAD -DBoost_DEBUG=1 -DPYTHON_VERSION=${TRAVIS_PYTHON_VERSION:0:3} ..
   - make
+  - find . -name "*.o" | xargs rm -v
   - ctest --output-on-failure


### PR DESCRIPTION
Includes some build fixes for Mac that change how brew is used. In particular, this tries to avoid uninstalling any packages that could be useful. Also, it skips updating brew so that packages like Boost don't have to be downloaded and installed as they are outdated (one of the longer ones). Finally, cleans up a bunch of build intermediates on Mac and Linux to hopefully improve memory usage. This appears to cut down the build time to ~35min for the Mac builds. 