### PR TITLE
python: Add new functions unique() and relabelConsecutive()

### DIFF
--- a/vigranumpy/src/core/segmentation.cxx
+++ b/vigranumpy/src/core/segmentation.cxx
@@ -55,10 +55,10 @@
 
 #include <string>
 #include <cmath>
+#include <unordered_set>
+#include <unordered_map>
 
 #include <boost/python/stl_iterator.hpp>
-#include <boost/unordered_map.hpp>
-#include <boost/unordered_set.hpp>
 
 #include "tws.hxx"
 
@@ -1098,7 +1098,7 @@ pythonApplyMapping(NumpyArray<NDIM, Singleband<SrcVoxelType> > src,
 
     // Copy dict into a c++ unordered_map of ints,
     // which is ~10x faster than using a Python dict
-    typedef boost::unordered_map<SrcVoxelType, DestVoxelType> labelmap_t;
+    typedef std::unordered_map<SrcVoxelType, DestVoxelType> labelmap_t;
     labelmap_t labelmap(2*len(mapping)); // Using 2*N buckets seems to speed things up by 10%
 
     typedef stl_input_iterator<tuple> dict_iter_t;
@@ -1154,7 +1154,7 @@ template <class VoxelType, unsigned int NDIM>
 NumpyAnyArray
 pythonUnique(NumpyArray<NDIM, Singleband<VoxelType> > src)
 {
-    boost::unordered_set<VoxelType> labelset;
+    std::unordered_set<VoxelType> labelset;
     auto f = [&labelset](VoxelType px) { labelset.insert(px); };
     inspectMultiArray(src, f);
 
@@ -1180,7 +1180,7 @@ pythonRelabelConsecutive(NumpyArray<NDIM, Singleband<SrcVoxelType> > src,
     using namespace boost::python;
     res.reshapeIfEmpty(src.taggedShape(), "relabelConsecutive(): Output array has wrong shape.");
 
-    boost::unordered_map<SrcVoxelType, DestVoxelType> labelmap;
+    std::unordered_map<SrcVoxelType, DestVoxelType> labelmap;
     {
         PyAllowThreads _pythread;
 

--- a/vigranumpy/src/core/segmentation.cxx
+++ b/vigranumpy/src/core/segmentation.cxx
@@ -1184,12 +1184,11 @@ pythonRelabelConsecutive(NumpyArray<NDIM, Singleband<SrcVoxelType> > src,
         PyAllowThreads _pythread;
 
         boost::unordered_map<SrcVoxelType, DestVoxelType> labelmap;
-        auto labelmap_end = labelmap.end();
 
         transformMultiArray(src, res,
             [&](SrcVoxelType px) -> DestVoxelType {
                 auto iter = labelmap.find(px);
-                if (iter != labelmap_end)
+                if (iter != labelmap.end())
                 {
                     return iter->second;
                 }

--- a/vigranumpy/test/test_segmentation.py
+++ b/vigranumpy/test/test_segmentation.py
@@ -96,7 +96,9 @@ def _impl_relabelConsecutive(dtype):
     a = numpy.random.randint(start,start+100, size=(100,100) ).astype(dtype)
     a[-1] = numpy.arange(start,start+100, dtype=dtype) # Make sure every number is used
     a[:] *= 3
-    consecutive = vigra.analysis.relabelConsecutive(a, start)
+    consecutive, maxlabel, mapping = vigra.analysis.relabelConsecutive(a, start)
+    assert maxlabel == consecutive.max()
+    assert (vigra.analysis.applyMapping(a, mapping) == consecutive).all()
 
     assert (numpy.unique(consecutive) == numpy.arange(start,start+100)).all(), \
         "relabeled array does not have consecutive labels"
@@ -107,7 +109,10 @@ def _impl_relabelConsecutive(dtype):
 
     # Now in-place
     orig = a.copy()
-    vigra.analysis.relabelConsecutive(a, start, out=a)
+    consecutive, maxlabel, mapping = vigra.analysis.relabelConsecutive(a, start, out=a)
+    assert consecutive is a
+    assert maxlabel == consecutive.max()
+    assert (vigra.analysis.applyMapping(orig, mapping) == consecutive).all()
     
     assert (numpy.unique(a) == numpy.arange(start,start+100)).all(), \
         "relabeled array does not have consecutive labels"

--- a/vigranumpy/test/test_segmentation.py
+++ b/vigranumpy/test/test_segmentation.py
@@ -81,5 +81,16 @@ def test_applyMapping():
     _impl_test_applyMapping(numpy.uint32)
     _impl_test_applyMapping(numpy.uint64)
 
+
+def _impl_test_unique(dtype):
+    a = numpy.array([2,3,5,7,11,13,17,19,23,29] + [2,3,5,7,11,13,17,19,23,29], dtype=dtype)
+    u = vigra.analysis.unique(a)
+    assert set(u) == set([2,3,5,7,11,13,17,19,23,29])
+
+def test_unique():
+    _impl_test_unique(numpy.uint8)
+    _impl_test_unique(numpy.uint32)
+    _impl_test_unique(numpy.uint64)
+
 def ok_():
     print(".", file=sys.stderr)

--- a/vigranumpy/test/test_segmentation.py
+++ b/vigranumpy/test/test_segmentation.py
@@ -81,7 +81,6 @@ def test_applyMapping():
     _impl_test_applyMapping(numpy.uint32)
     _impl_test_applyMapping(numpy.uint64)
 
-
 def _impl_test_unique(dtype):
     a = numpy.array([2,3,5,7,11,13,17,19,23,29] + [2,3,5,7,11,13,17,19,23,29], dtype=dtype)
     u = vigra.analysis.unique(a)
@@ -91,6 +90,36 @@ def test_unique():
     _impl_test_unique(numpy.uint8)
     _impl_test_unique(numpy.uint32)
     _impl_test_unique(numpy.uint64)
+
+def _impl_relabelConsecutive(dtype):
+    start = 17
+    a = numpy.random.randint(start,start+100, size=(100,100) ).astype(dtype)
+    a[-1] = numpy.arange(start,start+100, dtype=dtype) # Make sure every number is used
+    a[:] *= 3
+    consecutive = vigra.analysis.relabelConsecutive(a, start)
+
+    assert (numpy.unique(consecutive) == numpy.arange(start,start+100)).all(), \
+        "relabeled array does not have consecutive labels"
+    
+    first_label_a = a[0,0]
+    first_label_c = consecutive[0,0]
+    assert ((a == first_label_a) == (consecutive == first_label_c)).all()
+
+    # Now in-place
+    orig = a.copy()
+    vigra.analysis.relabelConsecutive(a, start, out=a)
+    
+    assert (numpy.unique(a) == numpy.arange(start,start+100)).all(), \
+        "relabeled array does not have consecutive labels"
+    
+    first_label_orig = orig[0,0]
+    first_label_a = a[0,0]
+    assert ((orig == first_label_orig) == (a == first_label_a)).all()
+
+def test_relabelConsecutive():
+    _impl_relabelConsecutive(numpy.uint8)
+    _impl_relabelConsecutive(numpy.uint32)
+    _impl_relabelConsecutive(numpy.uint64)
 
 def ok_():
     print(".", file=sys.stderr)


### PR DESCRIPTION
This PR adds two more functions that are helpful when dealing with huge label volumes.  This implementation of `unique()` is 3x faster than `numpy.unique()`. Similarly, this implementation of`relabelConsecutive()` is much faster than the best python implementation I could come up with.