### PR TITLE
Fix for failing boost graph concept checking.

### DIFF
--- a/include/vigra/multi_gridgraph.hxx
+++ b/include/vigra/multi_gridgraph.hxx
@@ -3081,6 +3081,22 @@ ostream& operator<<(ostream& out,
 
 } // namespace std
 
+#ifdef WITH_BOOST_GRAPH
+namespace boost {
+    using vigra::boost_graph::out_edges;
+    using vigra::boost_graph::out_degree;
+    using vigra::boost_graph::source;
+    using vigra::boost_graph::target;
+    using vigra::boost_graph::in_edges;
+    using vigra::boost_graph::in_degree;
+    using vigra::boost_graph::adjacent_vertices;
+    using vigra::boost_graph::vertices;
+    using vigra::boost_graph::edges;
+    using vigra::boost_graph::edge;
+    using vigra::boost_graph::num_vertices;
+    using vigra::boost_graph::num_edges;
+}
+#endif /* WITH_BOOST_GRAPH */
 
 
 #endif /* VIGRA_MULTI_GRIDGRAPH_HXX */


### PR DESCRIPTION
See also latest comment in #260.

Boost graph concept checking fails for me in test_gridgraph_BGL. This commit makes these graph functions available in the boost namespace again, such that the concept checking works.