### PR TITLE
Determinant calculation by minors

### DIFF
--- a/include/vigra/linear_solve.hxx
+++ b/include/vigra/linear_solve.hxx
@@ -94,16 +94,15 @@ T determinantByLUDecomposition(MultiArrayView<2, T, C1> const & a)
 }
 
 template <class T, class C1>
-T determinantByMinors(MultiArrayView<2, T, C1> const & mat)
+typename NumericTraits<T>::Promote
+determinantByMinors(MultiArrayView<2, T, C1> const & mat)
 {
+    typedef typename NumericTraits<T>::Promote PromoteType;
     MultiArrayIndex m = rowCount(mat);
     MultiArrayIndex n = columnCount(mat);
     vigra_precondition(
             n == m,
             "determinant(): square matrix required.");
-    vigra_precondition(
-            NumericTraits<T>::isSigned::value,
-            "determinant(): signed type required.");
     if (m == 1)
     {
         return mat(0, 0);
@@ -111,7 +110,7 @@ T determinantByMinors(MultiArrayView<2, T, C1> const & mat)
     else
     {
         Matrix<T> minor_mat(Shape2(m-1, n-1));
-        T det = NumericTraits<T>::zero();
+        PromoteType det = NumericTraits<PromoteType>::zero();
         for (MultiArrayIndex i = 0; i < m; i++)
         {
             for (MultiArrayIndex j = 0, jj = 0; j < (m - 1); j++, jj++)
@@ -122,7 +121,7 @@ T determinantByMinors(MultiArrayView<2, T, C1> const & mat)
                 }
                 rowVector(minor_mat, j) = rowVector(mat, Shape2(jj, 1), m);
             }
-            const T sign = 1 - 2 * (i % 2);
+            const PromoteType sign = 1 - 2 * (i % 2);
             det += sign * mat(i, 0) * determinantByMinors(minor_mat);
         }
         return det;
@@ -851,8 +850,10 @@ TemporaryMatrix<T> inverse(const TemporaryMatrix<T> &v)
         Namespaces: vigra and vigra::linalg
      */
 template <class T, class C1>
-T determinant(MultiArrayView<2, T, C1> const & a, std::string method = "default")
+typename NumericTraits<T>::Promote
+determinant(MultiArrayView<2, T, C1> const & a, std::string method = "default")
 {
+    typedef typename NumericTraits<T>::Promote PromoteType;
     MultiArrayIndex n = columnCount(a);
     vigra_precondition(rowCount(a) == n,
                "determinant(): Square matrix required.");    
@@ -877,10 +878,10 @@ T determinant(MultiArrayView<2, T, C1> const & a, std::string method = "default"
     }
     else if(method == "cholesky")
     {
-        Matrix<T> L(a.shape());
+        Matrix<PromoteType> L(a.shape());
         vigra_precondition(choleskyDecomposition(a, L),
            "determinant(): Cholesky method requires symmetric positive definite matrix.");
-        T det = L(0,0);
+        PromoteType det = L(0,0);
         for(MultiArrayIndex k=1; k<n; ++k)
             det *= L(k,k);
         return sq(det);
@@ -889,7 +890,7 @@ T determinant(MultiArrayView<2, T, C1> const & a, std::string method = "default"
     {
         vigra_precondition(false, "determinant(): Unknown solution method.");
     }
-    return T();
+    return PromoteType();
 }
 
     /** Compute the logarithm of the determinant of a symmetric positive definite matrix.

--- a/include/vigra/linear_solve.hxx
+++ b/include/vigra/linear_solve.hxx
@@ -104,7 +104,10 @@ determinantByMinors(MultiArrayView<2, T, C1> const & mat)
     MultiArrayIndex n = columnCount(mat);
     vigra_precondition(
             n == m,
-            "determinant(): square matrix required.");
+            "determinantByMinors(): square matrix required.");
+    vigra_precondition(
+            NumericTraits<PromoteType>::isSigned::value,
+            "determinantByMinors(): promote type must be signed.");
     if (m == 1)
     {
         return mat(0, 0);
@@ -880,10 +883,10 @@ determinant(MultiArrayView<2, T, C1> const & a, std::string method = "default")
     }
     else if(method == "cholesky")
     {
-        Matrix<PromoteType> L(a.shape());
+        Matrix<T> L(a.shape());
         vigra_precondition(choleskyDecomposition(a, L),
            "determinant(): Cholesky method requires symmetric positive definite matrix.");
-        PromoteType det = L(0,0);
+        T det = L(0,0);
         for(MultiArrayIndex k=1; k<n; ++k)
             det *= L(k,k);
         return sq(det);

--- a/include/vigra/linear_solve.hxx
+++ b/include/vigra/linear_solve.hxx
@@ -93,6 +93,42 @@ T determinantByLUDecomposition(MultiArrayView<2, T, C1> const & a)
     return det;
 }
 
+template <class T, class C1>
+T determinantByMinors(MultiArrayView<2, T, C1> const & mat)
+{
+    MultiArrayIndex m = rowCount(mat);
+    MultiArrayIndex n = columnCount(mat);
+    vigra_precondition(
+            n == m,
+            "determinant(): square matrix required.");
+    vigra_precondition(
+            NumericTraits<T>::isSigned::value,
+            "determinant(): signed type required.");
+    if (m == 1)
+    {
+        return mat(0, 0);
+    }
+    else
+    {
+        Matrix<T> minor_mat(Shape2(m-1, n-1));
+        T det = NumericTraits<T>::zero();
+        for (MultiArrayIndex i = 0; i < m; i++)
+        {
+            for (MultiArrayIndex j = 0, jj = 0; j < (m - 1); j++, jj++)
+            {
+                if (j == i)
+                {
+                    jj++;
+                }
+                rowVector(minor_mat, j) = rowVector(mat, Shape2(jj, 1), m);
+            }
+            const T sign = 1 - 2 * (i % 2);
+            det += sign * mat(i, 0) * determinantByMinors(minor_mat);
+        }
+        return det;
+    }
+}
+
 // returns the new value of 'a' (when this Givens rotation is applied to 'a' and 'b')
 // the new value of 'b' is zero, of course
 template <class T>
@@ -801,12 +837,13 @@ TemporaryMatrix<T> inverse(const TemporaryMatrix<T> &v)
 
         \a method must be one of the following:
         <DL>
+        <DT>"default"<DD> Use "minor" for integral types and "LU" for any other.
         <DT>"Cholesky"<DD> Compute the solution by means of Cholesky decomposition. This
                            method is faster than "LU", but requires the matrix \a a 
                            to be symmetric positive definite. If this is 
                            not the case, a <tt>ContractViolation</tt> exception is thrown.
-                           
-        <DT>"LU"<DD> (default) Compute the solution by means of LU decomposition.
+        <DT>"LU"<DD> Compute the solution by means of LU decomposition.
+        <DT>"minor"<DD> Compute the solution by means of determinants of minors.
         </DL>
 
         <b>\#include</b> \<vigra/linear_solve.hxx\> or<br>
@@ -814,14 +851,18 @@ TemporaryMatrix<T> inverse(const TemporaryMatrix<T> &v)
         Namespaces: vigra and vigra::linalg
      */
 template <class T, class C1>
-T determinant(MultiArrayView<2, T, C1> const & a, std::string method = "LU")
+T determinant(MultiArrayView<2, T, C1> const & a, std::string method = "default")
 {
     MultiArrayIndex n = columnCount(a);
     vigra_precondition(rowCount(a) == n,
                "determinant(): Square matrix required.");    
 
     method = tolower(method);
-    
+
+    if(method == "default")
+    {
+        method = NumericTraits<T>::isIntegral::value ? "minor" : "lu";
+    }
     if(n == 1)
         return a(0,0);
     if(n == 2)
@@ -829,6 +870,10 @@ T determinant(MultiArrayView<2, T, C1> const & a, std::string method = "LU")
     if(method == "lu")
     {
         return detail::determinantByLUDecomposition(a);
+    }
+    else if(method == "minor")
+    {
+        return detail::determinantByMinors(a);
     }
     else if(method == "cholesky")
     {

--- a/include/vigra/linear_solve.hxx
+++ b/include/vigra/linear_solve.hxx
@@ -59,8 +59,10 @@ T determinantByLUDecomposition(MultiArrayView<2, T, C1> const & a)
 
     MultiArrayIndex m = rowCount(a), n = columnCount(a);
     vigra_precondition(n == m,
-       "determinant(): square matrix required.");
-       
+        "determinantByLUDecomposition(): square matrix required.");
+    vigra_precondition(NumericTraits<T>::isIntegral::value == false,
+        "determinantByLUDecomposition(): Input matrix must not be an integral type.");
+
     Matrix<T> LU(a);
     T det = 1.0;
 
@@ -955,6 +957,8 @@ bool choleskyDecomposition(MultiArrayView<2, T, C1> const & A,
                            MultiArrayView<2, T, C2> &L)
 {
     MultiArrayIndex n = columnCount(A); 
+    vigra_precondition(NumericTraits<T>::isIntegral::value == false,
+                       "choleskyDecomposition(): Input matrix must not be an integral type.");
     vigra_precondition(rowCount(A) == n,
                        "choleskyDecomposition(): Input matrix must be square.");
     vigra_precondition(n == columnCount(L) && n == rowCount(L),

--- a/test/math/test.cxx
+++ b/test/math/test.cxx
@@ -2717,18 +2717,18 @@ struct LinalgTest
             shouldEqual(determinant(mns3), -21);
         }
         {
-            unsigned int ds2[] = {1, 2, 2, 1};
-            unsigned int dns2[] = {1, 2, 3, 1};
-            vigra::Matrix<unsigned int> ms2(Shape(2,2), ds2);
-            vigra::Matrix<unsigned int> mns2(Shape(2,2), dns2);
+            unsigned short ds2[] = {1, 2, 2, 1};
+            unsigned short dns2[] = {1, 2, 3, 1};
+            vigra::Matrix<unsigned short> ms2(Shape(2,2), ds2);
+            vigra::Matrix<unsigned short> mns2(Shape(2,2), dns2);
             shouldEqual(determinant(ms2), -3);
             shouldEqual(determinant(mns2), -5);
         }
         {
-            unsigned int ds3[] = {1, 2, 3, 2, 3, 1, 3, 1, 2};
-            unsigned int dns3[] = {1, 2, 3, 5, 3, 1, 3, 1, 2};
-            vigra::Matrix<unsigned int> ms3(Shape(3,3), ds3);
-            vigra::Matrix<unsigned int> mns3(Shape(3,3), dns3);
+            unsigned short ds3[] = {1, 2, 3, 2, 3, 1, 3, 1, 2};
+            unsigned short dns3[] = {1, 2, 3, 5, 3, 1, 3, 1, 2};
+            vigra::Matrix<unsigned short> ms3(Shape(3,3), ds3);
+            vigra::Matrix<unsigned short> mns3(Shape(3,3), dns3);
             shouldEqual(determinant(ms3), -18);
             shouldEqual(determinant(mns3), -21);
         }

--- a/test/math/test.cxx
+++ b/test/math/test.cxx
@@ -2676,26 +2676,46 @@ struct LinalgTest
 
     void testDeterminant()
     {
-        double ds2[] = {1, 2, 2, 1};
-        double dns2[] = {1, 2, 3, 1};
-        Matrix ms2(Shape(2,2), ds2);
-        Matrix mns2(Shape(2,2), dns2);
-        double eps = 1e-12;
-        shouldEqualTolerance(determinant(ms2), -3.0, eps);
-        shouldEqualTolerance(determinant(mns2), -5.0, eps);
-        shouldEqualTolerance(logDeterminant(transpose(ms2)*ms2), std::log(9.0), eps);
-        shouldEqualTolerance(logDeterminant(transpose(mns2)*mns2), std::log(25.0), eps);
-
-        double ds3[] = {1, 2, 3, 2, 3, 1, 3, 1, 2};
-        double dns3[] = {1, 2, 3, 5, 3, 1, 3, 1, 2};
-        Matrix ms3(Shape(3,3), ds3);
-        Matrix mns3(Shape(3,3), dns3);
-        shouldEqualTolerance(determinant(ms3), -18.0, eps);
-        shouldEqualTolerance(determinant(mns3), -21.0, eps);
-        shouldEqualTolerance(determinant(transpose(ms3)*ms3, "Cholesky"), 324.0, eps);
-        shouldEqualTolerance(determinant(transpose(mns3)*mns3, "Cholesky"), 441.0, eps);
-        shouldEqualTolerance(logDeterminant(transpose(ms3)*ms3), std::log(324.0), eps);
-        shouldEqualTolerance(logDeterminant(transpose(mns3)*mns3), std::log(441.0), eps);
+        {
+            double eps = 1e-12;
+            double ds2[] = {1, 2, 2, 1};
+            double dns2[] = {1, 2, 3, 1};
+            Matrix ms2(Shape(2,2), ds2);
+            Matrix mns2(Shape(2,2), dns2);
+            shouldEqualTolerance(determinant(ms2), -3.0, eps);
+            shouldEqualTolerance(determinant(mns2), -5.0, eps);
+            shouldEqualTolerance(logDeterminant(transpose(ms2)*ms2), std::log(9.0), eps);
+            shouldEqualTolerance(logDeterminant(transpose(mns2)*mns2), std::log(25.0), eps);
+        }
+        {
+            double eps = 1e-12;
+            double ds3[] = {1, 2, 3, 2, 3, 1, 3, 1, 2};
+            double dns3[] = {1, 2, 3, 5, 3, 1, 3, 1, 2};
+            Matrix ms3(Shape(3,3), ds3);
+            Matrix mns3(Shape(3,3), dns3);
+            shouldEqualTolerance(determinant(ms3), -18.0, eps);
+            shouldEqualTolerance(determinant(mns3), -21.0, eps);
+            shouldEqualTolerance(determinant(transpose(ms3)*ms3, "Cholesky"), 324.0, eps);
+            shouldEqualTolerance(determinant(transpose(mns3)*mns3, "Cholesky"), 441.0, eps);
+            shouldEqualTolerance(logDeterminant(transpose(ms3)*ms3), std::log(324.0), eps);
+            shouldEqualTolerance(logDeterminant(transpose(mns3)*mns3), std::log(441.0), eps);
+        }
+        {
+            int ds2[] = {1, 2, 2, 1};
+            int dns2[] = {1, 2, 3, 1};
+            vigra::Matrix<int> ms2(Shape(2,2), ds2);
+            vigra::Matrix<int> mns2(Shape(2,2), dns2);
+            shouldEqual(determinant(ms2), -3.0);
+            shouldEqual(determinant(mns2), -5.0);
+        }
+        {
+            int ds3[] = {1, 2, 3, 2, 3, 1, 3, 1, 2};
+            int dns3[] = {1, 2, 3, 5, 3, 1, 3, 1, 2};
+            vigra::Matrix<int> ms3(Shape(3,3), ds3);
+            vigra::Matrix<int> mns3(Shape(3,3), dns3);
+            shouldEqual(determinant(ms3), -18);
+            shouldEqual(determinant(mns3), -21);
+        }
     }
 
     void testSVD()

--- a/test/math/test.cxx
+++ b/test/math/test.cxx
@@ -2705,14 +2705,30 @@ struct LinalgTest
             int dns2[] = {1, 2, 3, 1};
             vigra::Matrix<int> ms2(Shape(2,2), ds2);
             vigra::Matrix<int> mns2(Shape(2,2), dns2);
-            shouldEqual(determinant(ms2), -3.0);
-            shouldEqual(determinant(mns2), -5.0);
+            shouldEqual(determinant(ms2), -3);
+            shouldEqual(determinant(mns2), -5);
         }
         {
             int ds3[] = {1, 2, 3, 2, 3, 1, 3, 1, 2};
             int dns3[] = {1, 2, 3, 5, 3, 1, 3, 1, 2};
             vigra::Matrix<int> ms3(Shape(3,3), ds3);
             vigra::Matrix<int> mns3(Shape(3,3), dns3);
+            shouldEqual(determinant(ms3), -18);
+            shouldEqual(determinant(mns3), -21);
+        }
+        {
+            unsigned int ds2[] = {1, 2, 2, 1};
+            unsigned int dns2[] = {1, 2, 3, 1};
+            vigra::Matrix<unsigned int> ms2(Shape(2,2), ds2);
+            vigra::Matrix<unsigned int> mns2(Shape(2,2), dns2);
+            shouldEqual(determinant(ms2), -3);
+            shouldEqual(determinant(mns2), -5);
+        }
+        {
+            unsigned int ds3[] = {1, 2, 3, 2, 3, 1, 3, 1, 2};
+            unsigned int dns3[] = {1, 2, 3, 5, 3, 1, 3, 1, 2};
+            vigra::Matrix<unsigned int> ms3(Shape(3,3), ds3);
+            vigra::Matrix<unsigned int> mns3(Shape(3,3), dns3);
             shouldEqual(determinant(ms3), -18);
             shouldEqual(determinant(mns3), -21);
         }


### PR DESCRIPTION
The determinant calculation by LU decomposition fails for integral types. This commit introduces the determinant calculation by calculation of the minors. It also sets the default determinant calculation for integral types to "minor" and includes a unittest.