### PR TITLE
Added blockwise functions to vigranumpy

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ build_script:
     - if "%PY_VERSION%" == "2.7" set PATH=C:\\Miniconda-x64\\Scripts;%PATH%
     - if "%PY_VERSION%" == "3.5" set PATH=C:\\Miniconda3-x64\\Scripts;%PATH%
     - if "%PY_VERSION%" == "2.7" conda create -q --yes -n python -c ukoethe --override-channels visual-studio=%VC_VERSION%.0 python=%PY_VERSION% jpeg libpng libtiff hdf5 fftw boost numpy nose
-    - if "%PY_VERSION%" == "3.5" conda create -q --yes -n python python=%PY_VERSION% jpeg libpng libtiff hdf5 numpy nose
+    - if "%PY_VERSION%" == "3.5" conda create -q --yes -n python python=%PY_VERSION% jpeg libpng libtiff hdf5=1.8.15.1 numpy nose
     - activate python
     - if "%PY_VERSION%" == "3.5" conda install -q --yes -c ukoethe --override-channels visual-studio=%VC_VERSION%.0 fftw boost
     - cd %APPVEYOR_BUILD_FOLDER%

--- a/include/vigra/python_utility.hxx
+++ b/include/vigra/python_utility.hxx
@@ -41,6 +41,7 @@
 #include <string>
 #include "vigra/error.hxx"
 #include "vigra/tinyvector.hxx"
+#include "array_vector.hxx"
 
 namespace vigra {
 

--- a/vigranumpy/lib/__init__.py
+++ b/vigranumpy/lib/__init__.py
@@ -2616,42 +2616,117 @@ def _genBlockwiseFunctions():
     blockwise.convolutionOptions = convolutionOptions
     blockwise.convOpts = convolutionOptions
 
+    def labelOptions(blockShape, neighborhood=None, backgroundValue=None, numThreads=cpu_count()):
+        options = blockwise.BlockwiseLabelOptions()
+        options.blockShape = blockShape
+        options.numThreads = numThreads
+
+        if backgroundValue is not None:
+            options.backgroundValue = backgroundValue
+
+        if neighborhood == "indirect":
+            options.neighborhood = blockwise.NeighborhoodType.IndirectNeighborhood
+        elif neighborhood == "direct":
+            options.neighborhood = blockwise.NeighborhoodType.DirectNeighborhood
+        elif neighborhood is not None:
+            options.neighborhood = neighborhood
+
+        return options
+
+    labelOptions.__module__ = 'vigra.blockwise'
+    blockwise.labelOptions = labelOptions
+    blockwise.labelOpts = labelOptions
+
     def gaussianSmooth(image,options,out=None):
         out = blockwise._gaussianSmooth(image,options,out)
         return out
+
     gaussianSmooth.__module__ = 'vigra.blockwise'
     blockwise.gaussianSmooth = gaussianSmooth
 
     def gaussianGradient(image,options,out=None):
         out = blockwise._gaussianGradient(image,options,out)
         return out
+
     gaussianGradient.__module__ = 'vigra.blockwise'
     blockwise.gaussianGradient = gaussianGradient
 
     def gaussianGradientMagnitude(image,options,out=None):
         out = blockwise._gaussianGradientMagnitude(image,options,out)
         return out
+
     gaussianGradientMagnitude.__module__ = 'vigra.blockwise'
     blockwise.gaussianGradientMagnitude = gaussianGradientMagnitude
 
+    def gaussianDivergence(image, options, out=None):
+        out = blockwise._gaussianDivergence(image, options, out)
+        return out
+
+    gaussianDivergence.__module__ = 'vigra.blockwise'
+    blockwise.gaussianDivergence = gaussianDivergence
+
+    def hessianOfGaussian(image, options, out=None):
+        out = blockwise._hessianOfGaussian(image, options, out)
+        return out
+
+    hessianOfGaussian.__module__ = 'vigra.blockwise'
+    blockwise.hessianOfGaussian = hessianOfGaussian
 
     def hessianOfGaussianEigenvalues(image,options,out=None):
         out = blockwise._hessianOfGaussianEigenvalues(image,options,out)
         return out
+
     hessianOfGaussianEigenvalues.__module__ = 'vigra.blockwise'
     blockwise.hessianOfGaussianEigenvalues = hessianOfGaussianEigenvalues
 
     def hessianOfGaussianFirstEigenvalue(image,options,out=None):
         out = blockwise._hessianOfGaussianFirstEigenvalue(image,options,out)
         return out
+
     hessianOfGaussianFirstEigenvalue.__module__ = 'vigra.blockwise'
     blockwise.hessianOfGaussianFirstEigenvalue = hessianOfGaussianFirstEigenvalue
 
     def hessianOfGaussianLastEigenvalue(image,options,out=None):
         out = blockwise._hessianOfGaussianLastEigenvalue(image,options,out)
         return out
+
     hessianOfGaussianLastEigenvalue.__module__ = 'vigra.blockwise'
     blockwise.hessianOfGaussianLastEigenvalue = hessianOfGaussianLastEigenvalue
+
+    def laplacianOfGaussian(image,options,out=None):
+        out = blockwise._laplacianOfGaussian(image,options,out)
+        return out
+
+    laplacianOfGaussian.__module__ = 'vigra.blockwise'
+    blockwise.laplacianOfGaussian = laplacianOfGaussian
+
+    def symmetricGradient(image, options,out=None):
+        out = blockwise._symmetricGradient(image, options, out)
+        return out
+
+    symmetricGradient.__module__ = 'vigra.blockwise'
+    blockwise.symmetricGradient = symmetricGradient
+
+    def structureTensor(image, options, out = None):
+        out = blockwise._structureTensor(image, options, out)
+        return out
+
+    structureTensor.__module__ = 'vigra.blockwise'
+    blockwise.structureTensor = structureTensor
+
+    def unionFindWatersheds(data, options, labels=None):
+        labels = blockwise._unionFindWatersheds(data, options, labels)
+        return labels
+
+    unionFindWatersheds.__module__ = 'vigra.blockwise'
+    blockwise.unionFindWatersheds = unionFindWatersheds
+
+    def labelArray(data, options, labels=None):
+        labels = blockwise._labelArray(data, options, labels)
+        return labels
+
+    labelArray.__module__ = 'vigra.blockwise'
+    blockwise.labelArray = labelArray
 
 
 _genBlockwiseFunctions()

--- a/vigranumpy/src/core/blockwise.cxx
+++ b/vigranumpy/src/core/blockwise.cxx
@@ -58,7 +58,7 @@ NumpyAnyArray FUNCTOR(                              \
     const BlockwiseConvolutionOptions<DIM>  & opt,  \
     NumpyArray<DIM, T_OUT> dest                     \
 ){                                                  \
-    dest.reshapeIfEmpty(source.taggedShape());      \
+    dest.reshapeIfEmpty(source.Shape());            \
     FUNCTION(source, dest, opt);                    \
     return dest;                                    \
 }
@@ -279,8 +279,8 @@ void defineBlockwiseLabelOptions()
     python::class_<Opt>("BlockwiseLabelOptions", python::init<>())
     .add_property("blockShape", &Opt::readBlockShape, &Opt::setBlockShape)
     .add_property("numThreads", &Opt::getNumThreads, &Opt::setNumThreads)
-    .add_property("backgroundValue", &Opt:: template getBackgroundValue<double>,
-            python::make_function(&Opt:: template ignoreBackgroundValue<double>, python::return_internal_reference<>()))
+    .add_property("backgroundValue", &Opt::getBackgroundValue<double>,
+            python::make_function(&Opt::ignoreBackgroundValue<double>, python::return_internal_reference<>()))
     .add_property("neighbourhood", &Opt::getNeighborhood,
             python::make_function(&Opt::neighborhood, python::return_internal_reference<>()))
     .def("hasBackgroundValue", &Opt::hasBackgroundValue)

--- a/vigranumpy/src/core/blockwise.cxx
+++ b/vigranumpy/src/core/blockwise.cxx
@@ -412,8 +412,8 @@ BOOST_PYTHON_MODULE_INIT(blockwise)
     defineUnionFindWatershedsImpl<2, npy_uint32, npy_uint32>();
     defineUnionFindWatershedsImpl<3, npy_uint32, npy_uint32>();
 
-    defineLabelArrayImpl<2, npy_uint32, npy_uint32>();
-    defineLabelArrayImpl<3, npy_uint32, npy_uint32>();
+    defineLabelArrayImpl<2, npy_uint8, npy_uint32>();
+    defineLabelArrayImpl<3, npy_uint8, npy_uint32>();
     defineLabelArrayImpl<2, npy_uint32, npy_uint32>();
     defineLabelArrayImpl<3, npy_uint32, npy_uint32>();
 }

--- a/vigranumpy/src/core/blockwise.cxx
+++ b/vigranumpy/src/core/blockwise.cxx
@@ -406,8 +406,14 @@ BOOST_PYTHON_MODULE_INIT(blockwise)
 
     defineBlockwiseFilters<2, npy_float32, npy_float32>();
     defineBlockwiseFilters<3, npy_float32, npy_float32>();
+
+    defineUnionFindWatershedsImpl<2, npy_uint8, npy_uint32>();
+    defineUnionFindWatershedsImpl<3, npy_uint8, npy_uint32>();
     defineUnionFindWatershedsImpl<2, npy_uint32, npy_uint32>();
     defineUnionFindWatershedsImpl<3, npy_uint32, npy_uint32>();
+
+    defineLabelArrayImpl<2, npy_uint32, npy_uint32>();
+    defineLabelArrayImpl<3, npy_uint32, npy_uint32>();
     defineLabelArrayImpl<2, npy_uint32, npy_uint32>();
     defineLabelArrayImpl<3, npy_uint32, npy_uint32>();
 }

--- a/vigranumpy/src/core/blockwise.cxx
+++ b/vigranumpy/src/core/blockwise.cxx
@@ -317,6 +317,8 @@ BOOST_PYTHON_MODULE_INIT(blockwise)
     defineBlockwiseFilters<2, npy_float32, npy_float32>();
     defineBlockwiseFilters<3, npy_float32, npy_float32>();
 
+    defineUnionFindWatershedsImpl<2, npy_uint8, npy_uint32>();
+    defineUnionFindWatershedsImpl<3, npy_uint8, npy_uint32>();
     defineUnionFindWatershedsImpl<2, npy_uint32, npy_uint32>();
     defineUnionFindWatershedsImpl<3, npy_uint32, npy_uint32>();
 

--- a/vigranumpy/src/core/blockwise.cxx
+++ b/vigranumpy/src/core/blockwise.cxx
@@ -58,7 +58,7 @@ NumpyAnyArray FUNCTOR(                              \
     const BlockwiseConvolutionOptions<DIM>  & opt,  \
     NumpyArray<DIM, T_OUT> dest                     \
 ){                                                  \
-    dest.reshapeIfEmpty(source.Shape());            \
+    dest.reshapeIfEmpty(source.shape());            \
     FUNCTION(source, dest, opt);                    \
     return dest;                                    \
 }

--- a/vigranumpy/src/core/blockwise.cxx
+++ b/vigranumpy/src/core/blockwise.cxx
@@ -58,7 +58,7 @@ NumpyAnyArray FUNCTOR(                              \
     const BlockwiseConvolutionOptions<DIM>  & opt,  \
     NumpyArray<DIM, T_OUT> dest                     \
 ){                                                  \
-    dest.reshapeIfEmpty(source.shape());            \
+    dest.reshapeIfEmpty(source.taggedShape());      \
     FUNCTION(source, dest, opt);                    \
     return dest;                                    \
 }

--- a/vigranumpy/src/core/blockwise.cxx
+++ b/vigranumpy/src/core/blockwise.cxx
@@ -368,8 +368,8 @@ void defineBlockwiseLabelOptions()
     python::class_<Opt>("BlockwiseLabelOptions", python::init<>())
     .add_property("blockShape", &Opt::readBlockShape, &Opt::setBlockShape)
     .add_property("numThreads", &Opt::getNumThreads, &Opt::setNumThreads)
-    .add_property("backgroundValue", &Opt:: template getBackgroundValue<double>,
-            python::make_function(&Opt:: template ignoreBackgroundValue<double>, python::return_internal_reference<>()))
+    .add_property("backgroundValue", &Opt::getBackgroundValue<double>,
+            python::make_function(&Opt::ignoreBackgroundValue<double>, python::return_internal_reference<>()))
     .add_property("neighborhood", &Opt::getNeighborhood,
             python::make_function(&Opt::neighborhood, python::return_internal_reference<>()))
     .def("hasBackgroundValue", &Opt::hasBackgroundValue)

--- a/vigranumpy/src/core/blockwise.cxx
+++ b/vigranumpy/src/core/blockwise.cxx
@@ -1,6 +1,6 @@
 /************************************************************************/
 /*                                                                      */
-/*                 Copyright 2011 by Ullrich Koethe                     */
+/*      Copyright 2011 by Ullrich Koethe and Kevin Kiefer               */
 /*                                                                      */
 /*    This file is part of the VIGRA computer vision library.           */
 /*    The VIGRA Website is                                              */
@@ -38,238 +38,254 @@
 
 #include <vigra/numpy_array.hxx>
 #include <vigra/numpy_array_converters.hxx>
-
+#include <vigra/tinyvector.hxx>
 #include <vigra/multi_blocking.hxx>
 #include <vigra/multi_blockwise.hxx>
+#include <vigra/blockwise_labeling.hxx>
+#include <vigra/blockwise_watersheds.hxx>
+
 
 namespace python = boost::python;
 
 
-
-
 namespace vigra{
 
-    template<unsigned int DIM, class T_IN, class T_OUT>
-    NumpyAnyArray pyBlockwiseGaussianSmoothMultiArray(
-        const NumpyArray<DIM, T_IN> &  source,
-        const BlockwiseConvolutionOptions<DIM>  & opt,
-        NumpyArray<DIM, T_OUT>  dest
-    ){
-        dest.reshapeIfEmpty(source.taggedShape());
-        gaussianSmoothMultiArray(source, dest, opt);
-        return dest;
-    }
 
-    template<unsigned int DIM, class T_IN, class T_OUT>
-    NumpyAnyArray pyBlockwiseGaussianGradientMagnitudeMultiArray(
-        const NumpyArray<DIM, T_IN> &  source,
-        const BlockwiseConvolutionOptions<DIM>  & opt,
-        NumpyArray<DIM, T_OUT>  dest
-    ){
-        dest.reshapeIfEmpty(source.taggedShape());
-        gaussianGradientMagnitudeMultiArray(source, dest, opt);
-        return dest;
-    }
+#define VIGRA_NUMPY_FILTERS(FUNCTOR, FUNCTION)      \
+template<unsigned int DIM, class T_IN, class T_OUT> \
+NumpyAnyArray FUNCTOR(                              \
+    const NumpyArray<DIM, T_IN> &  source,          \
+    const BlockwiseConvolutionOptions<DIM>  & opt,  \
+    NumpyArray<DIM, T_OUT> dest                     \
+){                                                  \
+    dest.reshapeIfEmpty(source.shape());            \
+    FUNCTION(source, dest, opt);                    \
+    return dest;                                    \
+}
 
-    template<unsigned int DIM, class T_IN, class T_OUT>
-    NumpyAnyArray pyBlockwiseGaussianGradientMultiArray(
-        const NumpyArray<DIM, T_IN> &  source,
-        const BlockwiseConvolutionOptions<DIM>  & opt,
-        NumpyArray<DIM, T_OUT>  dest
-    ){
-        dest.reshapeIfEmpty(source.taggedShape());
-        gaussianGradientMultiArray(source, dest, opt);
-        return dest;
-    }
+VIGRA_NUMPY_FILTERS(pyGaussianSmooth,                     gaussianSmoothMultiArray)
+VIGRA_NUMPY_FILTERS(pyGaussianGradient,                   gaussianGradientMultiArray)
+VIGRA_NUMPY_FILTERS(pyGaussianGradientMagnitude,          gaussianGradientMagnitudeMultiArray)
+VIGRA_NUMPY_FILTERS(pyGaussianDivergence,                 gaussianDivergenceMultiArray)
+VIGRA_NUMPY_FILTERS(pyHessianOfGaussian,                  hessianOfGaussianMultiArray)
+VIGRA_NUMPY_FILTERS(pyHessianOfGaussianEigenvalues,       hessianOfGaussianEigenvaluesMultiArray)
+VIGRA_NUMPY_FILTERS(pyHessianOfGaussianFirstEigenvalue,   hessianOfGaussianFirstEigenvalueMultiArray)
+VIGRA_NUMPY_FILTERS(pyHessianOfGaussianLastEigenvalue,    hessianOfGaussianLastEigenvalueMultiArray)
+VIGRA_NUMPY_FILTERS(pyLaplacianOfGaussian,                laplacianOfGaussianMultiArray)
+VIGRA_NUMPY_FILTERS(pySymmetricGradient,                  symmetricGradientMultiArray)
+VIGRA_NUMPY_FILTERS(pyStructureTensor,                    structureTensorMultiArray)
 
-    template<unsigned int DIM, class T_IN, class T_OUT>
-    NumpyAnyArray pyBlockwiseHessianOfGaussianEigenvaluesMultiArray(
-        const NumpyArray<DIM, T_IN> &  source,
-        const BlockwiseConvolutionOptions<DIM>  & opt,
-        NumpyArray<DIM, T_OUT>  dest
-    ){
-        dest.reshapeIfEmpty(source.taggedShape());
-        hessianOfGaussianEigenvaluesMultiArray(source, dest, opt);
-        return dest;
-    }
-
-    template<unsigned int DIM, class T_IN, class T_OUT>
-    NumpyAnyArray pyBlockwiseHessianOfGaussianFirstEigenvalueMultiArray(
-        const NumpyArray<DIM, T_IN> &  source,
-        const BlockwiseConvolutionOptions<DIM>  & opt,
-        NumpyArray<DIM, T_OUT>  dest
-    ){
-        dest.reshapeIfEmpty(source.taggedShape());
-        hessianOfGaussianFirstEigenvalueMultiArray(source, dest, opt);
-        return dest;
-    }
-
-    template<unsigned int DIM, class T_IN, class T_OUT>
-    NumpyAnyArray pyBlockwiseHessianOfGaussianLastEigenvalueMultiArray(
-        const NumpyArray<DIM, T_IN> &  source,
-        const BlockwiseConvolutionOptions<DIM>  & opt,
-        NumpyArray<DIM, T_OUT>  dest
-    ){
-        dest.reshapeIfEmpty(source.taggedShape());
-        hessianOfGaussianLastEigenvalueMultiArray(source, dest, opt);
-        return dest;
-    }
+#undef VIGRA_NUMPY_FILTERS
 
 
 
+#define VIGRA_NUMPY_FILTER_BINDINGS(NAME_STR, FUNCTOR, T_IN, T_OUT) \
+python::def(NAME_STR, registerConverters(&FUNCTOR<N,T_IN,T_OUT>),   \
+    (                                                               \
+        python::arg("source"),                                      \
+        python::arg("options"),                                     \
+        python::arg("out") = python::object()                       \
+    )                                                               \
+);
 
-    template<unsigned int DIM, class T_IN>
-    void defineBlockwiseFilters(){
-        //typedef BlockwiseConvolutionOptions<DIM> Opt;
+template<unsigned int N, class T_IN, class T_OUT>
+void defineBlockwiseFilters(){
+    typedef TinyVector<T_IN,N> in_type;
+    typedef TinyVector<T_OUT,N> out_type;
+    typedef TinyVector<T_OUT,N*(N+1)/2> out_type_2;
 
-        python::def("_gaussianSmooth",registerConverters(&pyBlockwiseGaussianSmoothMultiArray<DIM, T_IN, float>),
+    VIGRA_NUMPY_FILTER_BINDINGS("_gaussianSmooth",                  pyGaussianSmooth,                   T_IN,    T_OUT)
+    VIGRA_NUMPY_FILTER_BINDINGS("_gaussianGradient",                pyGaussianGradient,                 T_IN,    out_type)
+    VIGRA_NUMPY_FILTER_BINDINGS("_gaussianGradientMagnitude",       pyGaussianGradientMagnitude,        T_IN,    T_OUT)
+    VIGRA_NUMPY_FILTER_BINDINGS("_gaussianDivergence",              pyGaussianDivergence,               in_type, T_OUT)
+    VIGRA_NUMPY_FILTER_BINDINGS("_hessianOfGaussian",               pyHessianOfGaussian,                T_IN,    out_type_2)
+    VIGRA_NUMPY_FILTER_BINDINGS("_hessianOfGaussianEigenvalues",    pyHessianOfGaussianEigenvalues,     T_IN,    out_type)
+    VIGRA_NUMPY_FILTER_BINDINGS("_hessianOfGaussianFirstEigenvalue",pyHessianOfGaussianFirstEigenvalue, T_IN,    T_OUT)
+    VIGRA_NUMPY_FILTER_BINDINGS("_hessianOfGaussianLastEigenvalue", pyHessianOfGaussianLastEigenvalue,  T_IN,    T_OUT)
+    VIGRA_NUMPY_FILTER_BINDINGS("_laplacianOfGaussian",             pyLaplacianOfGaussian,              T_IN,    T_OUT)
+    VIGRA_NUMPY_FILTER_BINDINGS("_symmetricGradient",               pySymmetricGradient,                T_IN,    out_type)
+    VIGRA_NUMPY_FILTER_BINDINGS("_structureTensor",                 pyStructureTensor,                  T_IN,    out_type_2)
+}
+
+#undef VIGRA_NUMPY_FILTER_BINDINGS
+
+
+
+template<unsigned int N, class T_IN, class T_OUT>
+python::tuple pyUnionFindWatersheds(
+    const NumpyArray<N, T_IN> & data,
+    const BlockwiseLabelOptions & opt,
+    NumpyArray<N, T_OUT> labels
+){
+    labels.reshapeIfEmpty(data.shape());
+    auto res = unionFindWatershedsBlockwise(data, labels, opt);
+    return python::make_tuple(labels, res);
+}
+
+template<unsigned int N, class Data, class Label>
+void defineUnionFindWatershedsImpl()
+{
+    python::def("_unionFindWatersheds", registerConverters(&pyUnionFindWatersheds<N,Data,Label>),
+        (
+            python::arg("data"),
+            python::arg("options"),
+            python::arg("labels") = python::object()
+        )
+    );
+}
+
+
+
+template<unsigned int N, class T_IN, class T_OUT>
+python::tuple pyLabelArray(
+    const NumpyArray<N, T_IN> & data,
+    const BlockwiseLabelOptions & opt,
+    NumpyArray<N, T_OUT> labels
+){
+    labels.reshapeIfEmpty(data.shape());
+    auto res = labelMultiArrayBlockwise(data, labels, opt);
+    return python::make_tuple(labels, res);
+}
+
+template<unsigned int N, class Data, class Label>
+void defineLabelArrayImpl()
+{
+    python::def("_labelArray", registerConverters(&pyLabelArray<N,Data,Label>),
+        (
+            python::arg("data"),
+            python::arg("options"),
+            python::arg("labels") = python::object()
+        )
+    );
+}
+
+
+
+template<class  MB>
+NumpyAnyArray intersectingBlocks(
+    const MB & mb,
+    const typename MB::Shape begin,
+    const typename MB::Shape end,
+    NumpyArray<1, UInt32> out
+){
+    std::vector<UInt32> outVec = mb.intersectingBlocks(begin,end);
+    out.reshapeIfEmpty(typename NumpyArray<1,UInt32>::difference_type(outVec.size()));
+    std::copy(outVec.begin(),outVec.end(), out.begin());
+    return out;
+}
+
+template<class  MB>
+python::tuple getBlock(
+    const MB & mb,
+    const UInt32 blockIndex
+){
+    const auto iter = mb.blockBegin();
+    const auto & block = iter[blockIndex];
+    auto tl = block.begin();
+    auto br = block.end();
+    return python::make_tuple(tl,br);
+}
+
+
+template<class  MB>
+python::tuple getBlock2(
+    const MB & mb,
+    const typename  MB::BlockDesc desc
+){
+    const auto block = mb.blockDescToBlock(desc);
+    auto tl = block.begin();
+    auto br = block.end();
+    return python::make_tuple(tl,br);
+}
+
+template<class BLOCK>
+typename BLOCK::Vector
+blockBegin(const BLOCK & b){
+    return b.begin();
+}
+template<class BLOCK>
+typename BLOCK::Vector
+blockEnd(const BLOCK & b){
+    return b.end();
+}
+
+template<class BLOCK>
+typename BLOCK::Vector
+blockShape(const BLOCK & b){
+    return b.size();
+}
+
+
+template<unsigned int DIM>
+void defineMultiBlocking(const std::string & clsName){
+
+    typedef MultiBlocking<DIM> Blocking;
+    typedef typename Blocking::Shape Shape;
+    typedef typename Blocking::Block Block;
+
+    python::class_<Blocking>(clsName.c_str(), python::init<const Shape &, const Shape &>())
+        .def("intersectingBlocks",registerConverters(&intersectingBlocks<Blocking>),
             (
-                python::arg("source"),
-                python::arg("options"),
+                python::arg("begin"),
+                python::arg("end"),
                 python::arg("out") = python::object()
             )
-        );
+        )
+        .def("__len__", &Blocking::numBlocks)
+        .def("__getitem__", &getBlock<Blocking>)
+        .def("__getitem__", &getBlock2<Blocking>)
+    ;
 
-        python::def("_gaussianGradientMagnitude",registerConverters(&pyBlockwiseGaussianGradientMagnitudeMultiArray<DIM, T_IN, float>),
-            (
-                python::arg("source"),
-                python::arg("options"),
-                python::arg("out") = python::object()
-            )
-        );
+    const std::string blockName = clsName + std::string("Block");
 
-        python::def("_gaussianGradient",registerConverters(&pyBlockwiseGaussianGradientMultiArray<DIM, T_IN, TinyVector<float, DIM> >),
-            (
-                python::arg("source"),
-                python::arg("options"),
-                python::arg("out") = python::object()
-            )
-        );
-
-        python::def("_hessianOfGaussianEigenvalues",registerConverters(&pyBlockwiseHessianOfGaussianEigenvaluesMultiArray<DIM, T_IN, vigra::TinyVector<float, DIM> >),
-            (
-                python::arg("source"),
-                python::arg("options"),
-                python::arg("out") = python::object()
-            )
-        );
-        python::def("_hessianOfGaussianFirstEigenvalue",registerConverters(&pyBlockwiseHessianOfGaussianFirstEigenvalueMultiArray<DIM, T_IN, float>),
-            (
-                python::arg("source"),
-                python::arg("options"),
-                python::arg("out") = python::object()
-            )
-        );
-        python::def("_hessianOfGaussianLastEigenvalue",registerConverters(&pyBlockwiseHessianOfGaussianLastEigenvalueMultiArray<DIM, T_IN, float>),
-            (
-                python::arg("source"),
-                python::arg("options"),
-                python::arg("out") = python::object()
-            )
-        );
-    }
-
-    template<class  MB>
-    NumpyAnyArray intersectingBlocks(
-        const MB & mb,
-        const typename MB::Shape begin,
-        const typename MB::Shape end,
-        NumpyArray<1, UInt32> out
-    ){
-        std::vector<UInt32> outVec = mb.intersectingBlocks(begin,end);
-        out.reshapeIfEmpty(typename NumpyArray<1,UInt32>::difference_type(outVec.size()));
-        std::copy(outVec.begin(),outVec.end(), out.begin());
-        return out;
-    }
-
-    template<class  MB>
-    python::tuple getBlock(
-        const MB & mb,
-        const UInt32 blockIndex
-    ){
-        const auto iter = mb.blockBegin();
-        const auto & block = iter[blockIndex];
-        auto tl = block.begin();
-        auto br = block.end();
-        return python::make_tuple(tl,br);
-    }
-
-
-    template<class  MB>
-    python::tuple getBlock2(
-        const MB & mb,
-        const typename  MB::BlockDesc desc
-    ){
-        const auto block = mb.blockDescToBlock(desc);
-        auto tl = block.begin();
-        auto br = block.end();
-        return python::make_tuple(tl,br);
-    }
-
-    template<class BLOCK>
-    typename BLOCK::Vector
-    blockBegin(const BLOCK & b){
-        return b.begin();
-    }
-    template<class BLOCK>
-    typename BLOCK::Vector
-    blockEnd(const BLOCK & b){
-        return b.end();
-    }
-
-    template<class BLOCK>
-    typename BLOCK::Vector
-    blockShape(const BLOCK & b){
-        return b.size();
-    }
-
-
-    template<unsigned int DIM>
-    void defineMultiBlocking(const std::string & clsName){
-
-        typedef MultiBlocking<DIM> Blocking;
-        typedef typename Blocking::Shape Shape;
-        typedef typename Blocking::Block Block;
-
-        python::class_<Blocking>(clsName.c_str(), python::init<const Shape &, const Shape &>())
-            .def("intersectingBlocks",registerConverters(&intersectingBlocks<Blocking>),
-                (
-                    python::arg("begin"),
-                    python::arg("end"),
-                    python::arg("out") = python::object()
-                )
-            )
-            .def("__len__", &Blocking::numBlocks)
-            .def("__getitem__", &getBlock<Blocking>)
-            .def("__getitem__", &getBlock2<Blocking>)
-        ;
-
-        const std::string blockName = clsName + std::string("Block");
-
-        python::class_<Block>(blockName.c_str())
-            .add_property("begin",&blockBegin<Block>)
-            .add_property("end",  &blockEnd<Block>)
-            .add_property("shape",&blockShape<Block>)
-        ;
-    }
+    python::class_<Block>(blockName.c_str())
+        .add_property("begin",&blockBegin<Block>)
+        .add_property("end",  &blockEnd<Block>)
+        .add_property("shape",&blockShape<Block>)
+    ;
+}
 
 
 
-    template<unsigned int DIM>
-    void defineBlockwiseConvolutionOptions(const std::string & clsName){
+template<unsigned int DIM>
+void defineBlockwiseConvolutionOptions(const std::string & clsName){
 
-        typedef BlockwiseConvolutionOptions<DIM> Opt;
-        python::class_<Opt>(clsName.c_str(), python::init<>())
-        .add_property("stdDev", &Opt::getStdDev, &Opt::setStdDev)
-        //.add_property("scale", &Opt::getScale, &Opt::setScale)
-        .add_property("innerScale", &Opt::getInnerScale,  &Opt::setInnerScale)
-        .add_property("outerScale", &Opt::getOuterScale,  &Opt::setOuterScale)
-        .add_property("blockShape", &Opt::readBlockShape, &Opt::setBlockShape)
-        .add_property("numThreads", &Opt::getNumThreads,  &Opt::setNumThreads)
-        ;
-    }
+    typedef BlockwiseConvolutionOptions<DIM> Opt;
+    python::class_<Opt>(clsName.c_str(), python::init<>())
+    .add_property("stdDev", &Opt::getStdDev, &Opt::setStdDev)
+    //.add_property("scale", &Opt::getScale, &Opt::setScale)
+    .add_property("innerScale", &Opt::getInnerScale,  &Opt::setInnerScale)
+    .add_property("outerScale", &Opt::getOuterScale,  &Opt::setOuterScale)
+    .add_property("blockShape", &Opt::readBlockShape, &Opt::setBlockShape)
+    .add_property("numThreads", &Opt::getNumThreads,  &Opt::setNumThreads)
+    ;
+}
 
 
+void defineNeighborhoodType()
+{
+    python::enum_<NeighborhoodType>("NeighborhoodType")
+    .value("DirectNeighborhood", DirectNeighborhood)
+    .value("IndirectNeighborhood", IndirectNeighborhood)
+    .export_values()
+    ;
+}
+
+
+void defineBlockwiseLabelOptions()
+{
+    typedef BlockwiseLabelOptions Opt;
+
+    python::class_<Opt>("BlockwiseLabelOptions", python::init<>())
+    .add_property("blockShape", &Opt::readBlockShape, &Opt::setBlockShape)
+    .add_property("numThreads", &Opt::getNumThreads, &Opt::setNumThreads)
+    .add_property("backgroundValue", &Opt:: template getBackgroundValue<double>,
+            python::make_function(&Opt:: template ignoreBackgroundValue<double>, python::return_internal_reference<>()))
+    .add_property("neighbourhood", &Opt::getNeighborhood,
+            python::make_function(&Opt::neighborhood, python::return_internal_reference<>()))
+    .def("hasBackgroundValue", &Opt::hasBackgroundValue)
+    ;
+}
 
 }
 using namespace vigra;
@@ -293,8 +309,17 @@ BOOST_PYTHON_MODULE_INIT(blockwise)
     defineBlockwiseConvolutionOptions<2>("BlockwiseConvolutionOptions2D");
     defineBlockwiseConvolutionOptions<3>("BlockwiseConvolutionOptions3D");
     defineBlockwiseConvolutionOptions<4>("BlockwiseConvolutionOptions4D");
-    defineBlockwiseConvolutionOptions<5>("BlockwiseConvolutionOptions4D");
+    defineBlockwiseConvolutionOptions<5>("BlockwiseConvolutionOptions5D");
 
-    defineBlockwiseFilters<2, float>();
-    defineBlockwiseFilters<3, float>();
+    defineNeighborhoodType();
+    defineBlockwiseLabelOptions();
+
+    defineBlockwiseFilters<2, npy_float32, npy_float32>();
+    defineBlockwiseFilters<3, npy_float32, npy_float32>();
+
+    defineUnionFindWatershedsImpl<2, npy_uint32, npy_uint32>();
+    defineUnionFindWatershedsImpl<3, npy_uint32, npy_uint32>();
+
+    defineLabelArrayImpl<2, npy_uint32, npy_uint32>();
+    defineLabelArrayImpl<3, npy_uint32, npy_uint32>();
 }

--- a/vigranumpy/src/core/blockwise.cxx
+++ b/vigranumpy/src/core/blockwise.cxx
@@ -38,9 +38,9 @@
 
 #include <vigra/numpy_array.hxx>
 #include <vigra/numpy_array_converters.hxx>
-#include <vigra/tinyvector.hxx>
 #include <vigra/multi_blocking.hxx>
 #include <vigra/multi_blockwise.hxx>
+#include <vigra/tinyvector.hxx>
 #include <vigra/blockwise_labeling.hxx>
 #include <vigra/blockwise_watersheds.hxx>
 
@@ -51,35 +51,128 @@ namespace python = boost::python;
 namespace vigra{
 
 
-#define VIGRA_NUMPY_FILTERS(FUNCTOR, FUNCTION)      \
-template<unsigned int DIM, class T_IN, class T_OUT> \
-NumpyAnyArray FUNCTOR(                              \
-    const NumpyArray<DIM, T_IN> &  source,          \
-    const BlockwiseConvolutionOptions<DIM>  & opt,  \
-    NumpyArray<DIM, T_OUT> dest                     \
-){                                                  \
-    dest.reshapeIfEmpty(source.shape());            \
-    FUNCTION(source, dest, opt);                    \
-    return dest;                                    \
+template<unsigned int DIM, class T_IN, class T_OUT>
+NumpyAnyArray pyGaussianSmooth(
+    const NumpyArray<DIM, T_IN> &  source,
+    const BlockwiseConvolutionOptions<DIM>  & opt,
+    NumpyArray<DIM, T_OUT> dest
+){
+    dest.reshapeIfEmpty(source.taggedShape());
+    gaussianSmoothMultiArray(source, dest, opt);
+    return dest;
 }
 
-VIGRA_NUMPY_FILTERS(pyGaussianSmooth,                     gaussianSmoothMultiArray)
-VIGRA_NUMPY_FILTERS(pyGaussianGradient,                   gaussianGradientMultiArray)
-VIGRA_NUMPY_FILTERS(pyGaussianGradientMagnitude,          gaussianGradientMagnitudeMultiArray)
-VIGRA_NUMPY_FILTERS(pyGaussianDivergence,                 gaussianDivergenceMultiArray)
-VIGRA_NUMPY_FILTERS(pyHessianOfGaussian,                  hessianOfGaussianMultiArray)
-VIGRA_NUMPY_FILTERS(pyHessianOfGaussianEigenvalues,       hessianOfGaussianEigenvaluesMultiArray)
-VIGRA_NUMPY_FILTERS(pyHessianOfGaussianFirstEigenvalue,   hessianOfGaussianFirstEigenvalueMultiArray)
-VIGRA_NUMPY_FILTERS(pyHessianOfGaussianLastEigenvalue,    hessianOfGaussianLastEigenvalueMultiArray)
-VIGRA_NUMPY_FILTERS(pyLaplacianOfGaussian,                laplacianOfGaussianMultiArray)
-VIGRA_NUMPY_FILTERS(pySymmetricGradient,                  symmetricGradientMultiArray)
-VIGRA_NUMPY_FILTERS(pyStructureTensor,                    structureTensorMultiArray)
+template<unsigned int DIM, class T_IN, class T_OUT>
+NumpyAnyArray pyHessianOfGaussianFirstEigenvalue(
+    const NumpyArray<DIM, T_IN> &  source,
+    const BlockwiseConvolutionOptions<DIM>  & opt,
+    NumpyArray<DIM, T_OUT> dest
+){
+    dest.reshapeIfEmpty(source.taggedShape());
+    hessianOfGaussianFirstEigenvalueMultiArray(source, dest, opt);
+    return dest;
+}
 
-#undef VIGRA_NUMPY_FILTERS
+template<unsigned int DIM, class T_IN, class T_OUT>
+NumpyAnyArray pyGaussianGradientMagnitude(
+    const NumpyArray<DIM, T_IN> &  source,
+    const BlockwiseConvolutionOptions<DIM>  & opt,
+    NumpyArray<DIM, T_OUT> dest
+){
+    dest.reshapeIfEmpty(source.taggedShape());
+    gaussianGradientMagnitudeMultiArray(source, dest, opt);
+    return dest;
+}
 
+template<unsigned int DIM, class T_IN, class T_OUT>
+NumpyAnyArray pyHessianOfGaussianLastEigenvalue(
+    const NumpyArray<DIM, T_IN> &  source,
+    const BlockwiseConvolutionOptions<DIM>  & opt,
+    NumpyArray<DIM, T_OUT> dest
+){
+    dest.reshapeIfEmpty(source.taggedShape());
+    hessianOfGaussianLastEigenvalueMultiArray(source, dest, opt);
+    return dest;
+}
 
+template<unsigned int DIM, class T_IN, class T_OUT>
+NumpyAnyArray pyLaplacianOfGaussian(
+    const NumpyArray<DIM, T_IN> &  source,
+    const BlockwiseConvolutionOptions<DIM>  & opt,
+    NumpyArray<DIM, T_OUT> dest
+){
+    dest.reshapeIfEmpty(source.taggedShape());
+    laplacianOfGaussianMultiArray(source, dest, opt);
+    return dest;
+}
 
-#define VIGRA_NUMPY_FILTER_BINDINGS(NAME_STR, FUNCTOR, T_IN, T_OUT) \
+template<unsigned int DIM, class T_IN, class T_OUT>
+NumpyAnyArray pyGaussianDivergence(
+    const NumpyArray<DIM, TinyVector<T_IN, DIM> > & source,
+    const BlockwiseConvolutionOptions<DIM> & opt,
+    NumpyArray<DIM, T_OUT> dest
+){
+    dest.reshapeIfEmpty(source.taggedShape().setChannelCount(0));
+    gaussianDivergenceMultiArray(source, dest, opt);
+    return dest;
+}
+
+template<unsigned int DIM, class T_IN, class T_OUT>
+NumpyAnyArray pyGaussianGradient(
+    const NumpyArray<DIM, T_IN> & source,
+    const BlockwiseConvolutionOptions<DIM> & opt,
+    NumpyArray<DIM, TinyVector<T_OUT, DIM> > dest
+){
+    dest.reshapeIfEmpty(source.taggedShape().setChannelCount(DIM));
+    gaussianGradientMultiArray(source, dest, opt);
+    return dest;
+}
+
+template<unsigned int DIM, class T_IN, class T_OUT>
+NumpyAnyArray pyHessianOfGaussian(
+    const NumpyArray<DIM, T_IN> & source,
+    const BlockwiseConvolutionOptions<DIM> & opt,
+    NumpyArray<DIM, TinyVector<T_OUT, DIM*(DIM+1)/2> > dest
+){
+    dest.reshapeIfEmpty(source.taggedShape().setChannelCount(DIM*(DIM+1)/2));
+    hessianOfGaussianMultiArray(source, dest, opt);
+    return dest;
+}
+
+template<unsigned int DIM, class T_IN, class T_OUT>
+NumpyAnyArray pyHessianOfGaussianEigenvalues(
+    const NumpyArray<DIM, T_IN> & source,
+    const BlockwiseConvolutionOptions<DIM> & opt,
+    NumpyArray<DIM, TinyVector<T_OUT, DIM> > dest
+){
+    dest.reshapeIfEmpty(source.taggedShape().setChannelCount(DIM));
+    hessianOfGaussianEigenvaluesMultiArray(source, dest, opt);
+    return dest;
+}
+
+template<unsigned int DIM, class T_IN, class T_OUT>
+NumpyAnyArray pyStructureTensor(
+    const NumpyArray<DIM, T_IN> & source,
+    const BlockwiseConvolutionOptions<DIM> & opt,
+    NumpyArray<DIM, TinyVector<T_OUT, DIM*(DIM+1)/2> > dest
+){
+    dest.reshapeIfEmpty(source.taggedShape().setChannelCount(DIM*(DIM+1)/2));
+    structureTensorMultiArray(source, dest, opt);
+    return dest;
+}
+
+template<unsigned int DIM, class T_IN, class T_OUT>
+NumpyAnyArray pySymmetricGradient(
+    const NumpyArray<DIM, T_IN> & source,
+    const BlockwiseConvolutionOptions<DIM> & opt,
+    NumpyArray<DIM, TinyVector<T_OUT, DIM> > dest
+){
+    dest.reshapeIfEmpty(source.taggedShape().setChannelCount(DIM));
+    symmetricGradientMultiArray(source, dest, opt);
+    return dest;
+}
+
+#define VIGRA_NUMPY_FILTER_BINDINGS(NAME_STR, FUNCTOR)              \
 python::def(NAME_STR, registerConverters(&FUNCTOR<N,T_IN,T_OUT>),   \
     (                                                               \
         python::arg("source"),                                      \
@@ -90,21 +183,17 @@ python::def(NAME_STR, registerConverters(&FUNCTOR<N,T_IN,T_OUT>),   \
 
 template<unsigned int N, class T_IN, class T_OUT>
 void defineBlockwiseFilters(){
-    typedef TinyVector<T_IN,N> in_type;
-    typedef TinyVector<T_OUT,N> out_type;
-    typedef TinyVector<T_OUT,N*(N+1)/2> out_type_2;
-
-    VIGRA_NUMPY_FILTER_BINDINGS("_gaussianSmooth",                  pyGaussianSmooth,                   T_IN,    T_OUT)
-    VIGRA_NUMPY_FILTER_BINDINGS("_gaussianGradient",                pyGaussianGradient,                 T_IN,    out_type)
-    VIGRA_NUMPY_FILTER_BINDINGS("_gaussianGradientMagnitude",       pyGaussianGradientMagnitude,        T_IN,    T_OUT)
-    VIGRA_NUMPY_FILTER_BINDINGS("_gaussianDivergence",              pyGaussianDivergence,               in_type, T_OUT)
-    VIGRA_NUMPY_FILTER_BINDINGS("_hessianOfGaussian",               pyHessianOfGaussian,                T_IN,    out_type_2)
-    VIGRA_NUMPY_FILTER_BINDINGS("_hessianOfGaussianEigenvalues",    pyHessianOfGaussianEigenvalues,     T_IN,    out_type)
-    VIGRA_NUMPY_FILTER_BINDINGS("_hessianOfGaussianFirstEigenvalue",pyHessianOfGaussianFirstEigenvalue, T_IN,    T_OUT)
-    VIGRA_NUMPY_FILTER_BINDINGS("_hessianOfGaussianLastEigenvalue", pyHessianOfGaussianLastEigenvalue,  T_IN,    T_OUT)
-    VIGRA_NUMPY_FILTER_BINDINGS("_laplacianOfGaussian",             pyLaplacianOfGaussian,              T_IN,    T_OUT)
-    VIGRA_NUMPY_FILTER_BINDINGS("_symmetricGradient",               pySymmetricGradient,                T_IN,    out_type)
-    VIGRA_NUMPY_FILTER_BINDINGS("_structureTensor",                 pyStructureTensor,                  T_IN,    out_type_2)
+    VIGRA_NUMPY_FILTER_BINDINGS("_gaussianSmooth",                  pyGaussianSmooth)
+    VIGRA_NUMPY_FILTER_BINDINGS("_gaussianGradient",                pyGaussianGradient)
+    VIGRA_NUMPY_FILTER_BINDINGS("_gaussianGradientMagnitude",       pyGaussianGradientMagnitude)
+    VIGRA_NUMPY_FILTER_BINDINGS("_gaussianDivergence",              pyGaussianDivergence)
+    VIGRA_NUMPY_FILTER_BINDINGS("_hessianOfGaussian",               pyHessianOfGaussian)
+    VIGRA_NUMPY_FILTER_BINDINGS("_hessianOfGaussianEigenvalues",    pyHessianOfGaussianEigenvalues)
+    VIGRA_NUMPY_FILTER_BINDINGS("_hessianOfGaussianFirstEigenvalue",pyHessianOfGaussianFirstEigenvalue)
+    VIGRA_NUMPY_FILTER_BINDINGS("_hessianOfGaussianLastEigenvalue", pyHessianOfGaussianLastEigenvalue)
+    VIGRA_NUMPY_FILTER_BINDINGS("_laplacianOfGaussian",             pyLaplacianOfGaussian)
+    VIGRA_NUMPY_FILTER_BINDINGS("_symmetricGradient",               pySymmetricGradient)
+    VIGRA_NUMPY_FILTER_BINDINGS("_structureTensor",                 pyStructureTensor)
 }
 
 #undef VIGRA_NUMPY_FILTER_BINDINGS
@@ -117,7 +206,7 @@ python::tuple pyUnionFindWatersheds(
     const BlockwiseLabelOptions & opt,
     NumpyArray<N, T_OUT> labels
 ){
-    labels.reshapeIfEmpty(data.shape());
+    labels.reshapeIfEmpty(data.taggedShape());
     auto res = unionFindWatershedsBlockwise(data, labels, opt);
     return python::make_tuple(labels, res);
 }
@@ -142,7 +231,7 @@ python::tuple pyLabelArray(
     const BlockwiseLabelOptions & opt,
     NumpyArray<N, T_OUT> labels
 ){
-    labels.reshapeIfEmpty(data.shape());
+    labels.reshapeIfEmpty(data.taggedShape());
     auto res = labelMultiArrayBlockwise(data, labels, opt);
     return python::make_tuple(labels, res);
 }
@@ -279,13 +368,14 @@ void defineBlockwiseLabelOptions()
     python::class_<Opt>("BlockwiseLabelOptions", python::init<>())
     .add_property("blockShape", &Opt::readBlockShape, &Opt::setBlockShape)
     .add_property("numThreads", &Opt::getNumThreads, &Opt::setNumThreads)
-    .add_property("backgroundValue", &Opt::getBackgroundValue<double>,
-            python::make_function(&Opt::ignoreBackgroundValue<double>, python::return_internal_reference<>()))
-    .add_property("neighbourhood", &Opt::getNeighborhood,
+    .add_property("backgroundValue", &Opt:: template getBackgroundValue<double>,
+            python::make_function(&Opt:: template ignoreBackgroundValue<double>, python::return_internal_reference<>()))
+    .add_property("neighborhood", &Opt::getNeighborhood,
             python::make_function(&Opt::neighborhood, python::return_internal_reference<>()))
     .def("hasBackgroundValue", &Opt::hasBackgroundValue)
     ;
 }
+
 
 }
 using namespace vigra;
@@ -316,12 +406,8 @@ BOOST_PYTHON_MODULE_INIT(blockwise)
 
     defineBlockwiseFilters<2, npy_float32, npy_float32>();
     defineBlockwiseFilters<3, npy_float32, npy_float32>();
-
-    defineUnionFindWatershedsImpl<2, npy_uint8, npy_uint32>();
-    defineUnionFindWatershedsImpl<3, npy_uint8, npy_uint32>();
     defineUnionFindWatershedsImpl<2, npy_uint32, npy_uint32>();
     defineUnionFindWatershedsImpl<3, npy_uint32, npy_uint32>();
-
     defineLabelArrayImpl<2, npy_uint32, npy_uint32>();
     defineLabelArrayImpl<3, npy_uint32, npy_uint32>();
 }


### PR DESCRIPTION
modified: vigranumpy/lib/__init__.py
    Added functions to module 'vigra.blockwise'
        1) labelOptions - A factory for BlockwiseLabelOptions
        2) gaussianDivergence
        3) hessianOfGaussian
        4) laplacianOfGaussian
        5) symmetricGradient
        6) strucutreTensor
        7) unionFindWatersheds
        8) labelArray

modified: vigranumpy/src/core/blockwise.cxx
    Added classes to module 'vigra.blockwise'
        1) NeighborhoodType
        2) BlockwiseLabelOptions
    NOTE:
        The python bindings for the new functions provided by
        __init__.py are defined here.

minor bugfixes:
    in include/vigra/python_utility.hxx:
        Added:
            44: #include "array_vector.hxx"
        required by:
            436: python_ptr shapeToPythonTuple(ArrayVectorView<T> const & shape)

    in vigranumpy/src/core/blockwise.cxx:
        Changed line 312:
            defineBlockwiseConvolutionOptions<5>( \
                "BlockwiseConvolutionOptions4D");
        To:
            defineBlockwiseConvolutionOptions<5>( \
                "BlockwiseConvolutionOptions5D");