### PR TITLE
ChunkedArrayHDF5 constructed with chunkShape from HDF5 dataset if constructed with existing HDF5 File

### DIFF
--- a/include/vigra/mathutil.hxx
+++ b/include/vigra/mathutil.hxx
@@ -272,6 +272,15 @@ inline long long roundi(double t)
                 : (long long)(t - 0.5);
 }
 
+    /** \brief Determine whether x is a power of 2
+        Bit twiddle from https://graphics.stanford.edu/~seander/bithacks.html#DetermineIfPowerOf2
+    */
+inline bool isPower2(UInt32 x)
+{
+    return x && !(x & (x - 1));
+}
+
+
     /** \brief Round up to the nearest power of 2.
 
         Efficient algorithm for finding the smallest power of 2 which is not smaller than \a x
@@ -294,6 +303,7 @@ inline UInt32 ceilPower2(UInt32 x)
     x = x | (x >>16);
     return x + 1;
 }
+
 
     /** \brief Round down to the nearest power of 2.
 

--- a/include/vigra/multi_array_chunked.hxx
+++ b/include/vigra/multi_array_chunked.hxx
@@ -396,7 +396,6 @@ class ChunkedArrayBase
     , chunk_shape_()
     {}
 
-    // TODO with ceilPower2, we could check catch chunk shapes that are not power of 2 here 
     ChunkedArrayBase(shape_type const & shape, shape_type const & chunk_shape)
     : shape_(shape)
     , chunk_shape_(prod(chunk_shape) > 0 ? chunk_shape : detail::ChunkShape<N, T>::defaultShape())

--- a/include/vigra/multi_array_chunked.hxx
+++ b/include/vigra/multi_array_chunked.hxx
@@ -396,6 +396,7 @@ class ChunkedArrayBase
     , chunk_shape_()
     {}
 
+    // TODO with ceilPower2, we could check catch chunk shapes that are not power of 2 here 
     ChunkedArrayBase(shape_type const & shape, shape_type const & chunk_shape)
     : shape_(shape)
     , chunk_shape_(prod(chunk_shape) > 0 ? chunk_shape : detail::ChunkShape<N, T>::defaultShape())

--- a/include/vigra/multi_array_chunked_hdf5.hxx
+++ b/include/vigra/multi_array_chunked_hdf5.hxx
@@ -226,8 +226,9 @@ class ChunkedArrayHDF5
                      HDF5File::OpenMode mode = HDF5File::ReadOnly,
                      ChunkedArrayOptions const & options = ChunkedArrayOptions(),
                      Alloc const & alloc = Alloc())
-    // FIXME not checking for power of 2 chunk shapes yet, these will trigger some precondition error
-    : ChunkedArray<N, T>(shape_type(), shape_type(file.getChunkShape(dataset).begin()), options),
+    : ChunkedArray<N, T>(shape_type(),
+            ceilPower2<N>(shape_type(file.getChunkShape(dataset).begin())),
+            options),
       file_(file),
       dataset_name_(dataset),
       dataset_(),
@@ -235,6 +236,21 @@ class ChunkedArrayHDF5
       alloc_(alloc)
     {
         init(mode);
+    }
+
+
+    // copy constructor
+    ChunkedArrayHDF5(const ChunkedArrayHDF5 & src)
+    : ChunkedArray<N, T>(src),
+    file_(src.file_),
+    dataset_name_(src.dataset_name_),
+    compression_(src.compression_),
+    alloc_(src.alloc_)
+    {
+        if( file_.isReadOnly() )
+            init(HDF5File::ReadOnly);
+        else
+            init(HDF5File::ReadWrite);
     }
 
     void init(HDF5File::OpenMode mode)

--- a/include/vigra/multi_array_chunked_hdf5.hxx
+++ b/include/vigra/multi_array_chunked_hdf5.hxx
@@ -226,7 +226,8 @@ class ChunkedArrayHDF5
                      HDF5File::OpenMode mode = HDF5File::ReadOnly,
                      ChunkedArrayOptions const & options = ChunkedArrayOptions(),
                      Alloc const & alloc = Alloc())
-    : ChunkedArray<N, T>(shape_type(), shape_type(), options),
+    // FIXME not checking for power of 2 chunk shapes yet, these will trigger some precondition error
+    : ChunkedArray<N, T>(shape_type(), shape_type(file.getChunkShape(dataset).begin()), options),
       file_(file),
       dataset_name_(dataset),
       dataset_(),

--- a/include/vigra/tinyvector.hxx
+++ b/include/vigra/tinyvector.hxx
@@ -2337,6 +2337,30 @@ TinyVector<V, SIZE> clip(TinyVector<V, SIZE> const & t,
     }
     return res;
 }
+ 
+    /** \brief Round up values to the nearest power of 2.
+    Implemented only for UInt32
+    */
+template<int SIZE>
+inline TinyVector<UInt32,SIZE> ceilPower2(vigra::TinyVector<UInt32,SIZE> const & t)
+{
+    TinyVector<UInt32,SIZE> res(SkipInitialization);
+    for( size_t k = 0; k < SIZE; k++) 
+        res[k] = ceilPower2(t[k]);
+    return res;
+}
+ 
+    /** \brief Round down values to the nearest power of 2.
+    Implemented only for UInt32
+    */
+template<int SIZE>
+inline TinyVector<UInt32,SIZE> floorPower2(vigra::TinyVector<UInt32,SIZE> const & t)
+{
+    TinyVector<UInt32, SIZE> res(SkipInitialization);
+    for( size_t k = 0; k < SIZE; k++) 
+        res[k] = floorPower2(t[k]);
+    return res;
+}
 
 template<class V,int SIZE>
 inline


### PR DESCRIPTION
ChunkedArrayHDF5 is now created with the chunk shape of the underlying HDF5 dataset, if it is created with the constructor for an existing file.
For this, I had to implement getChunkShape as method of HDF5File, which returns the chunk shape of the dataset.
Still missing: If the HDF5 chunk size is not a power of 2, some precondition will fail.
We could fix this by going to the next bigger power of 2 if this is the case, but I don't know where the best place for this is, yet.