### PR TITLE
Enhancements to unique() and relabelConsecutive()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,8 +47,8 @@ before_script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew tap homebrew/science                                                           ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew remove --force $(grep -v -F -x -f <(cat <(brew deps --skip-optional --union $(echo -e $BREW_DEPS)) <(echo -e $BREW_DEPS))  <(cat <(brew leaves) <(brew deps --skip-optional --union $(brew leaves)))); brew cleanup --force ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install $(echo -e $BREW_DEPS) || true                                          ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ ${TRAVIS_PYTHON_VERSION:0:1} -eq 3 ]]; then sudo ln -s /usr/local/bin/pip3 /usr/local/bin/pip ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ ${TRAVIS_PYTHON_VERSION:0:1} -eq 3 ]]; then sudo ln -s /usr/local/bin/python3 /usr/local/bin/python ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ ${TRAVIS_PYTHON_VERSION:0:1} -eq 3 ]]; then sudo ln -s -f /usr/local/bin/pip3 /usr/local/bin/pip ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ ${TRAVIS_PYTHON_VERSION:0:1} -eq 3 ]]; then sudo ln -s -f /usr/local/bin/python3 /usr/local/bin/python ; fi
   - if [[ "$TRAVIS_PYTHON_VERSION" == "3.2" ]]; then pip install --upgrade 'pip<8' 'setuptools<19'                                ; fi
   - if [[ "$TRAVIS_PYTHON_VERSION" != "3.2" ]]; then pip install --upgrade pip setuptools                                         ; fi
   - pip install nose

--- a/vigranumpy/src/core/segmentation.cxx
+++ b/vigranumpy/src/core/segmentation.cxx
@@ -1619,7 +1619,7 @@ void defineSegmentation()
         "Much faster then ``numpy.unique()``.\n");
 
     //-- 3D relabelConsecutive
-    def("relabelConsecutive", registerConverters(&pythonRelabelConsecutive<3, npy_uint32, npy_uint32>),
+    def("relabelConsecutive", registerConverters(&pythonRelabelConsecutive<3, npy_uint64, npy_uint32>),
         (arg("labels"), arg("start_label")=1, arg("keep_zeros")=true, arg("out")=python::object()),
         "Relabel the given label image to have consecutive label values.\n"
         "Note: The relative order between label values will not necessarily be preserved.\n"
@@ -1638,25 +1638,26 @@ void defineSegmentation()
         "\n"
         "Note: As with other vigra functions, you should provide accurate axistags for optimal performance.\n");
     def("relabelConsecutive", registerConverters(&pythonRelabelConsecutive<3, npy_uint64, npy_uint64>), (arg("labels"), arg("start_label")=1, arg("keep_zeros")=true, arg("out")=python::object()));
+    def("relabelConsecutive", registerConverters(&pythonRelabelConsecutive<3, npy_uint32, npy_uint32>), (arg("labels"), arg("start_label")=1, arg("keep_zeros")=true, arg("out")=python::object()));
     def("relabelConsecutive", registerConverters(&pythonRelabelConsecutive<3, npy_uint8, npy_uint8>),   (arg("labels"), arg("start_label")=1, arg("keep_zeros")=true, arg("out")=python::object()));
-    def("relabelConsecutive", registerConverters(&pythonRelabelConsecutive<3, npy_uint64, npy_uint32>), (arg("labels"), arg("start_label")=1, arg("keep_zeros")=true, arg("out")=python::object()));
 
     //-- 2D relabelConsecutive
-    def("relabelConsecutive", registerConverters(&pythonRelabelConsecutive<2, npy_uint32, npy_uint32>), (arg("labels"), arg("start_label")=1, arg("keep_zeros")=true, arg("out")=python::object()));
-    def("relabelConsecutive", registerConverters(&pythonRelabelConsecutive<2, npy_uint64, npy_uint64>), (arg("labels"), arg("start_label")=1, arg("keep_zeros")=true, arg("out")=python::object()));
-    def("relabelConsecutive", registerConverters(&pythonRelabelConsecutive<2, npy_uint8, npy_uint8>),   (arg("labels"), arg("start_label")=1, arg("keep_zeros")=true, arg("out")=python::object()));
     def("relabelConsecutive", registerConverters(&pythonRelabelConsecutive<2, npy_uint64, npy_uint32>), (arg("labels"), arg("start_label")=1, arg("keep_zeros")=true, arg("out")=python::object()));
+    def("relabelConsecutive", registerConverters(&pythonRelabelConsecutive<2, npy_uint64, npy_uint64>), (arg("labels"), arg("start_label")=1, arg("keep_zeros")=true, arg("out")=python::object()));
+    def("relabelConsecutive", registerConverters(&pythonRelabelConsecutive<2, npy_uint32, npy_uint32>), (arg("labels"), arg("start_label")=1, arg("keep_zeros")=true, arg("out")=python::object()));
+    def("relabelConsecutive", registerConverters(&pythonRelabelConsecutive<2, npy_uint8, npy_uint8>),   (arg("labels"), arg("start_label")=1, arg("keep_zeros")=true, arg("out")=python::object()));
 
     //-- 1D relabelConsecutive
-    def("relabelConsecutive", registerConverters(&pythonRelabelConsecutive<1, npy_uint32, npy_uint32>), (arg("labels"), arg("start_label")=1, arg("keep_zeros")=true, arg("out")=python::object()));
-    def("relabelConsecutive", registerConverters(&pythonRelabelConsecutive<1, npy_uint64, npy_uint64>), (arg("labels"), arg("start_label")=1, arg("keep_zeros")=true, arg("out")=python::object()));
-    def("relabelConsecutive", registerConverters(&pythonRelabelConsecutive<1, npy_uint8, npy_uint8>),   (arg("labels"), arg("start_label")=1, arg("keep_zeros")=true, arg("out")=python::object()));
     def("relabelConsecutive", registerConverters(&pythonRelabelConsecutive<1, npy_uint64, npy_uint32>), (arg("labels"), arg("start_label")=1, arg("keep_zeros")=true, arg("out")=python::object()));
+    def("relabelConsecutive", registerConverters(&pythonRelabelConsecutive<1, npy_uint64, npy_uint64>), (arg("labels"), arg("start_label")=1, arg("keep_zeros")=true, arg("out")=python::object()));
+    def("relabelConsecutive", registerConverters(&pythonRelabelConsecutive<1, npy_uint32, npy_uint32>), (arg("labels"), arg("start_label")=1, arg("keep_zeros")=true, arg("out")=python::object()));
+    def("relabelConsecutive", registerConverters(&pythonRelabelConsecutive<1, npy_uint8, npy_uint8>),   (arg("labels"), arg("start_label")=1, arg("keep_zeros")=true, arg("out")=python::object()));
+
 
     // Lots of overloads here to allow mapping between arrays of different dtypes.
     // -- 3D
-    // 8 <--> 8, 32 <--> 32, 64 <--> 64
-    def("applyMapping", registerConverters(&pythonApplyMapping<3, npy_uint32, npy_uint32>),
+    // 64 --> 32
+    def("applyMapping", registerConverters(&pythonApplyMapping<3, npy_uint64, npy_uint32>),
         (arg("labels"), arg("mapping"), arg("allow_incomplete_mapping")=false, arg("out")=python::object()),
         "Map all values in `labels` to new values using the given mapping (a dict).\n"
         "Useful for maps with large values, for which a numpy index array would need too much RAM.\n"
@@ -1674,8 +1675,6 @@ void defineSegmentation()
         "     The dtype of ``out`` is allowed to be smaller (or bigger) than the dtype of ``labels``.\n"
         "\n"
         "Note: As with other vigra functions, you should provide accurate axistags for optimal performance.\n");
-    def("applyMapping", registerConverters(&pythonApplyMapping<3, npy_uint64, npy_uint64>), (arg("src"), arg("mapping"), arg("allow_incomplete_mapping")=false, arg("out")=python::object()));
-    def("applyMapping", registerConverters(&pythonApplyMapping<3, npy_uint8, npy_uint8>),   (arg("src"), arg("mapping"), arg("allow_incomplete_mapping")=false, arg("out")=python::object()));
 
     // 8 <--> 32
     def("applyMapping", registerConverters(&pythonApplyMapping<3, npy_uint8, npy_uint32>), (arg("src"), arg("mapping"), arg("allow_incomplete_mapping")=false, arg("out")=python::object()));
@@ -1683,18 +1682,19 @@ void defineSegmentation()
 
     // 32 <--> 64
     def("applyMapping", registerConverters(&pythonApplyMapping<3, npy_uint32, npy_uint64>), (arg("src"), arg("mapping"), arg("allow_incomplete_mapping")=false, arg("out")=python::object()));
-    def("applyMapping", registerConverters(&pythonApplyMapping<3, npy_uint64, npy_uint32>), (arg("src"), arg("mapping"), arg("allow_incomplete_mapping")=false, arg("out")=python::object()));
+    //def("applyMapping", registerConverters(&pythonApplyMapping<3, npy_uint64, npy_uint32>), (arg("src"), arg("mapping"), arg("allow_incomplete_mapping")=false, arg("out")=python::object()));
 
     // 8 <--> 64
     def("applyMapping", registerConverters(&pythonApplyMapping<3, npy_uint8, npy_uint64>), (arg("src"), arg("mapping"), arg("allow_incomplete_mapping")=false, arg("out")=python::object()));
     def("applyMapping", registerConverters(&pythonApplyMapping<3, npy_uint64, npy_uint8>), (arg("src"), arg("mapping"), arg("allow_incomplete_mapping")=false, arg("out")=python::object()));
 
-    // -- 2D
+    // Cases for same input/output dtypes must come last, so they are chosen by default!
     // 8 <--> 8, 32 <--> 32, 64 <--> 64
-    def("applyMapping", registerConverters(&pythonApplyMapping<2, npy_uint32, npy_uint32>), (arg("src"), arg("mapping"), arg("allow_incomplete_mapping")=false, arg("out")=python::object()));
-    def("applyMapping", registerConverters(&pythonApplyMapping<2, npy_uint64, npy_uint64>), (arg("src"), arg("mapping"), arg("allow_incomplete_mapping")=false, arg("out")=python::object()));
-    def("applyMapping", registerConverters(&pythonApplyMapping<2, npy_uint8, npy_uint8>),   (arg("src"), arg("mapping"), arg("allow_incomplete_mapping")=false, arg("out")=python::object()));
+    def("applyMapping", registerConverters(&pythonApplyMapping<3, npy_uint64, npy_uint64>), (arg("src"), arg("mapping"), arg("allow_incomplete_mapping")=false, arg("out")=python::object()));
+    def("applyMapping", registerConverters(&pythonApplyMapping<3, npy_uint32, npy_uint32>), (arg("src"), arg("mapping"), arg("allow_incomplete_mapping")=false, arg("out")=python::object()));
+    def("applyMapping", registerConverters(&pythonApplyMapping<3, npy_uint8, npy_uint8>),   (arg("src"), arg("mapping"), arg("allow_incomplete_mapping")=false, arg("out")=python::object()));
 
+    // -- 2D
     // 8 <--> 32
     def("applyMapping", registerConverters(&pythonApplyMapping<2, npy_uint8, npy_uint32>), (arg("src"), arg("mapping"), arg("allow_incomplete_mapping")=false, arg("out")=python::object()));
     def("applyMapping", registerConverters(&pythonApplyMapping<2, npy_uint32, npy_uint8>), (arg("src"), arg("mapping"), arg("allow_incomplete_mapping")=false, arg("out")=python::object()));
@@ -1707,11 +1707,13 @@ void defineSegmentation()
     def("applyMapping", registerConverters(&pythonApplyMapping<2, npy_uint8, npy_uint64>), (arg("src"), arg("mapping"), arg("allow_incomplete_mapping")=false, arg("out")=python::object()));
     def("applyMapping", registerConverters(&pythonApplyMapping<2, npy_uint64, npy_uint8>), (arg("src"), arg("mapping"), arg("allow_incomplete_mapping")=false, arg("out")=python::object()));
 
-    // -- 1D
+    // Cases for same input/output dtypes must come last, so they are chosen by default!
     // 8 <--> 8, 32 <--> 32, 64 <--> 64
-    def("applyMapping", registerConverters(&pythonApplyMapping<1, npy_uint32, npy_uint32>), (arg("src"), arg("mapping"), arg("allow_incomplete_mapping")=false, arg("out")=python::object()));
-    def("applyMapping", registerConverters(&pythonApplyMapping<1, npy_uint64, npy_uint64>), (arg("src"), arg("mapping"), arg("allow_incomplete_mapping")=false, arg("out")=python::object()));
-    def("applyMapping", registerConverters(&pythonApplyMapping<1, npy_uint8, npy_uint8>),   (arg("src"), arg("mapping"), arg("allow_incomplete_mapping")=false, arg("out")=python::object()));
+    def("applyMapping", registerConverters(&pythonApplyMapping<2, npy_uint32, npy_uint32>), (arg("src"), arg("mapping"), arg("allow_incomplete_mapping")=false, arg("out")=python::object()));
+    def("applyMapping", registerConverters(&pythonApplyMapping<2, npy_uint64, npy_uint64>), (arg("src"), arg("mapping"), arg("allow_incomplete_mapping")=false, arg("out")=python::object()));
+    def("applyMapping", registerConverters(&pythonApplyMapping<2, npy_uint8, npy_uint8>),   (arg("src"), arg("mapping"), arg("allow_incomplete_mapping")=false, arg("out")=python::object()));
+
+    // -- 1D
 
     // 8 <--> 32
     def("applyMapping", registerConverters(&pythonApplyMapping<1, npy_uint8, npy_uint32>), (arg("src"), arg("mapping"), arg("allow_incomplete_mapping")=false, arg("out")=python::object()));
@@ -1725,6 +1727,11 @@ void defineSegmentation()
     def("applyMapping", registerConverters(&pythonApplyMapping<1, npy_uint8, npy_uint64>), (arg("src"), arg("mapping"), arg("allow_incomplete_mapping")=false, arg("out")=python::object()));
     def("applyMapping", registerConverters(&pythonApplyMapping<1, npy_uint64, npy_uint8>), (arg("src"), arg("mapping"), arg("allow_incomplete_mapping")=false, arg("out")=python::object()));
 
+    // Cases for same input/output dtypes must come last, so they are chosen by default!
+    // 8 <--> 8, 32 <--> 32, 64 <--> 64
+    def("applyMapping", registerConverters(&pythonApplyMapping<1, npy_uint32, npy_uint32>), (arg("src"), arg("mapping"), arg("allow_incomplete_mapping")=false, arg("out")=python::object()));
+    def("applyMapping", registerConverters(&pythonApplyMapping<1, npy_uint64, npy_uint64>), (arg("src"), arg("mapping"), arg("allow_incomplete_mapping")=false, arg("out")=python::object()));
+    def("applyMapping", registerConverters(&pythonApplyMapping<1, npy_uint8, npy_uint8>),   (arg("src"), arg("mapping"), arg("allow_incomplete_mapping")=false, arg("out")=python::object()));
 }
 
 void defineEdgedetection();

--- a/vigranumpy/src/core/segmentation.cxx
+++ b/vigranumpy/src/core/segmentation.cxx
@@ -57,6 +57,7 @@
 #include <cmath>
 #include <unordered_set>
 #include <unordered_map>
+#include <algorithm>
 
 #include <boost/python/stl_iterator.hpp>
 
@@ -1152,7 +1153,7 @@ pythonApplyMapping(NumpyArray<NDIM, Singleband<SrcVoxelType> > src,
 */
 template <class VoxelType, unsigned int NDIM>
 NumpyAnyArray
-pythonUnique(NumpyArray<NDIM, Singleband<VoxelType> > src)
+pythonUnique(NumpyArray<NDIM, Singleband<VoxelType> > src, bool sort=true)
 {
     std::unordered_set<VoxelType> labelset;
     auto f = [&labelset](VoxelType px) { labelset.insert(px); };
@@ -1161,6 +1162,11 @@ pythonUnique(NumpyArray<NDIM, Singleband<VoxelType> > src)
     NumpyArray<1, VoxelType> result;
     result.reshape( Shape1(labelset.size()) );
     std::copy( labelset.begin(), labelset.end(), result.begin() );
+
+    if (sort)
+    {
+        std::sort( result.begin(), result.end() );
+    }
     return result;
 }
 
@@ -1590,11 +1596,11 @@ void defineSegmentation()
         "\n");
 
     multidef("unique",
-        pyUnique<1,5,npy_uint8, npy_uint32, npy_uint64>(),
-        (arg("arr")),
+        pyUnique<1,5,npy_uint8, npy_uint32, npy_uint64, npy_int64>(),
+        (arg("arr"), arg("sort")=true),
         "Find unique values in the given label array.\n"
-        "Result is not sorted.\n"
-        "Faster then numpy.unique().\n");
+        "If ``sort`` is True, then the output is sorted.\n"
+        "Much faster then ``numpy.unique()``.\n");
 
     //-- 3D relabelConsecutive
     def("relabelConsecutive", registerConverters(&pythonRelabelConsecutive<3, npy_uint32, npy_uint32>),

--- a/vigranumpy/test/test_segmentation.py
+++ b/vigranumpy/test/test_segmentation.py
@@ -71,7 +71,7 @@ def _impl_test_applyMapping(dtype):
     
     try:
         remapped = vigra.analysis.applyMapping(original, mapping, allow_incomplete_mapping=False)
-    except IndexError:
+    except KeyError:
         pass
     else:
         assert False, "Expected to get an exception due to the incomplete mapping!"

--- a/vigranumpy/test/test_segmentation.py
+++ b/vigranumpy/test/test_segmentation.py
@@ -126,5 +126,25 @@ def test_relabelConsecutive():
     _impl_relabelConsecutive(numpy.uint32)
     _impl_relabelConsecutive(numpy.uint64)
 
+def test_relabelConsecutive_keep_zeros():
+    a = numpy.arange(1,10, dtype=numpy.uint8)
+    a[1::2] = 0 # replace even numbers with zeros
+
+    # Check keep_zeros=True
+    consecutive, maxlabel, mapping = vigra.analysis.relabelConsecutive(a, start_label=100, keep_zeros=True)
+    assert (consecutive[1::2] == 0).all(), \
+        "Zeros were not left untouched!"
+    assert set(consecutive[0::2]) == set(range(100,100+len(consecutive[0::2]))), \
+        "Non-zero items were not correctly consecutivized!"
+    assert maxlabel == consecutive.max()
+    assert (vigra.analysis.applyMapping(a, mapping) == consecutive).all()
+
+    # Check keep_zeros=False
+    consecutive, maxlabel, mapping = vigra.analysis.relabelConsecutive(a, start_label=100, keep_zeros=False)
+    assert (numpy.unique(consecutive) == numpy.arange(100, 100+1+len(a[::2]))).all(), \
+        "relabeled array does not have consecutive labels: {}".format(consecutive)
+    assert maxlabel == consecutive.max()
+    assert (vigra.analysis.applyMapping(a, mapping) == consecutive).all()
+
 def ok_():
     print(".", file=sys.stderr)

--- a/vigranumpy/test/test_segmentation.py
+++ b/vigranumpy/test/test_segmentation.py
@@ -83,8 +83,8 @@ def test_applyMapping():
 
 def _impl_test_unique(dtype):
     a = numpy.array([2,3,5,7,11,13,17,19,23,29] + [2,3,5,7,11,13,17,19,23,29], dtype=dtype)
-    u = vigra.analysis.unique(a)
-    assert set(u) == set([2,3,5,7,11,13,17,19,23,29])
+    u = vigra.analysis.unique(a, sort=True)
+    assert (u == [2,3,5,7,11,13,17,19,23,29]).all()
 
 def test_unique():
     _impl_test_unique(numpy.uint8)

--- a/vigranumpy/test/test_segmentation.py
+++ b/vigranumpy/test/test_segmentation.py
@@ -41,6 +41,7 @@ def _impl_test_applyMapping(dtype):
 
     # Not in-place
     remapped = vigra.analysis.applyMapping(original, mapping)
+    assert remapped.dtype == original.dtype, "Default output dtype did not match input dtype!"
     assert (remapped == original+100).all()
 
     # in-place
@@ -97,6 +98,8 @@ def _impl_relabelConsecutive(dtype):
     a[-1] = numpy.arange(start,start+100, dtype=dtype) # Make sure every number is used
     a[:] *= 3
     consecutive, maxlabel, mapping = vigra.analysis.relabelConsecutive(a, start)
+
+    assert consecutive.dtype == consecutive.dtype, "Default output dtype did not match input dtype!"
     assert maxlabel == consecutive.max()
     assert (vigra.analysis.applyMapping(a, mapping) == consecutive).all()
 


### PR DESCRIPTION
Here are two tiny changes to make it easier for users to replace the horribly slow `numpy.unique()` with `vigra.analysis.unique()`:
- Support `int64`. (This is more commonly needed than I originally thought.)
- Sort the output by default, like `numpy.unique()` does.
