### PR TITLE
supportedConvexHullFeatures(): Updated for new 2D/3D function names

### DIFF
--- a/vigranumpy/lib/__init__.py
+++ b/vigranumpy/lib/__init__.py
@@ -687,19 +687,22 @@ def _genFeaturConvenienceFunctions():
     analysis.supportedRegionFeatures = supportedRegionFeatures
 
     def supportedConvexHullFeatures(labels):
-        '''Return a list of Convex Hull feature names that are available for the given 2D label array.
-           These Convex Hull feature names are the valid inputs to a call of
-           :func:`extractConvexHullFeatures`. E.g., to compute just the first two features in the
+        '''Return a list of Convex Hull feature names that are available for the given label array.
+           These Convex Hull feature names are the valid inputs to a call with
+           :func:`extract2DConvexHullFeatures` or `extract3DConvexHullFeatures`. E.g., to compute just the first two features in the
            list, use::
 
                 f = vigra.analysis.supportedConvexHullFeatures(labels)
                 print("Computing Convex Hull features:", f[:2])
-                r = vigra.analysis.extractConvexHullFeatures(labels, features=f[:2])
+                r = vigra.analysis.extract2DConvexHullFeatures(labels, features=f[:2])
         '''
         try:
-            return analysis.extractConvexHullFeatures(labels, list_features_only=True)
+            return analysis.extract2DConvexHullFeatures(labels, list_features_only=True)
         except:
-            return []
+            try:
+                return analysis.extract3DConvexHullFeatures(labels, list_features_only=True)
+            except:
+                return []
 
     supportedConvexHullFeatures.__module__ = 'vigra.analysis'
     analysis.supportedConvexHullFeatures = supportedConvexHullFeatures

--- a/vigranumpy/test/test_segmentation.py
+++ b/vigranumpy/test/test_segmentation.py
@@ -99,7 +99,7 @@ def _impl_relabelConsecutive(dtype):
     a[:] *= 3
     consecutive, maxlabel, mapping = vigra.analysis.relabelConsecutive(a, start)
 
-    assert consecutive.dtype == consecutive.dtype, "Default output dtype did not match input dtype!"
+    assert consecutive.dtype == a.dtype, "Default output dtype did not match input dtype!"
     assert maxlabel == consecutive.max()
     assert (vigra.analysis.applyMapping(a, mapping) == consecutive).all()
 


### PR DESCRIPTION
`vigra.analysis.supportedConvexHullFeatures()` is broken because it doesn't use the new function names for 2D/3D features.  Here's a quick fix.

A better fix would be for someone to modify the `extractConvexHullFeatures()` python bindings in `accumulator-region-singleband.cxx` to use `VIGRA_PYTHON_MULTITYPE_FUNCTOR_NDIM` and `multidef`, and then allow python users to use the name `extractConvexHullFeatures` for both 2D and 3D.

PS -- While I was at it, I made a tiny little fix in an unrelated test file.