### PR TITLE
fix intensity normalization in asRGB

### DIFF
--- a/vigranumpy/lib/arraytypes.py
+++ b/vigranumpy/lib/arraytypes.py
@@ -782,7 +782,7 @@ class VigraArray(numpy.ndarray):
                 clip = False
             if m == M:
                 return res
-            f = 255.0 // (M - m)
+            f = 255.0 / (M - m)
             img = f * (img - m)
             if clip:
                 img = numpy.minimum(255.0, numpy.maximum(0.0, img))


### PR DESCRIPTION
bug introduced in commit c69e2f1abb32324b03f861316d418aa4642b32d4
flooring division produces 0 if scaling factor is <1