### PR TITLE
Fix parameter of ImagePyramid::swap

### DIFF
--- a/include/vigra/imagecontainer.hxx
+++ b/include/vigra/imagecontainer.hxx
@@ -763,7 +763,7 @@ public:
         /** swap contents of this array with the contents of other
             (STL-Container interface)
          */
-    void swap(const ImagePyramid<ImageType, Alloc> &other)
+    void swap(ImagePyramid<ImageType, Alloc> &other)
     {
         images_.swap(other.images_);
         std::swap(lowestLevel_, other.lowestLevel_);


### PR DESCRIPTION
You can't swap with a const object. This fixes a compilation failure
with GCC 7 which rejects the incorrect function even if it isn't
instantiated.