### PR TITLE
Set VIGRA_CONFIGURATION in tests always

### DIFF
--- a/config/run_test.bat.in
+++ b/config/run_test.bat.in
@@ -5,7 +5,11 @@ if [%1] NEQ [] (
     set CONFIGURATION=Release
 )
 
-echo Testing configuration '%CONFIGURATION%'
+if "%CONFIGURATION%" EQU "." (
+    echo Testing configuration '@CMAKE_BUILD_TYPE@'
+) else (
+    echo Testing configuration '%CONFIGURATION%'
+)
 
 set PATH=@EXTRA_PATH@%PATH%
 

--- a/vigranumpy/test/CMakeLists.txt
+++ b/vigranumpy/test/CMakeLists.txt
@@ -153,11 +153,7 @@ IF(NOT PYTHON_NOSETESTS_NOT_FOUND)
     # variable CMAKE_CFG_INTDIR contains a dot '.' for a Windows nmake build, or
     #                           '$(OutDir)' for a VisualStudio build (OutDir will be
     #                           set by VS at build time)
-    IF(NOT CMAKE_CFG_INTDIR STREQUAL ".")
-        SET(VIGRA_CONFIGURATION ${CMAKE_CFG_INTDIR})
-    ELSE()
-        SET(VIGRA_CONFIGURATION)
-    ENDIF()
+    SET(VIGRA_CONFIGURATION ${CMAKE_CFG_INTDIR})
 
     IF(AUTOEXEC_TESTS)
         add_custom_command(


### PR DESCRIPTION
Fixes https://github.com/ukoethe/vigra/issues/413

Fixes an issue when running the tests with NMake by always setting `VIGRA_CONFIGURATION` to `CMAKE_CFG_INTDIR`.