### PR TITLE
src/impex/CMakeLists.txt: set CXX_STANDARD to 11

### DIFF
--- a/src/impex/CMakeLists.txt
+++ b/src/impex/CMakeLists.txt
@@ -67,9 +67,12 @@ ADD_LIBRARY(vigraimpex ${LIBTYPE}
 set(SOVERSION 11)  # increment this after changing the vigraimpex library
 IF(MACOSX)
     SET_TARGET_PROPERTIES(vigraimpex PROPERTIES VERSION ${SOVERSION}.${vigra_version}
-                         SOVERSION ${SOVERSION} INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}")
+                          SOVERSION ${SOVERSION} INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}"
+                          CXX_STANDARD 11)
 ELSE()
-    SET_TARGET_PROPERTIES(vigraimpex PROPERTIES VERSION ${SOVERSION}.${vigra_version} SOVERSION ${SOVERSION})
+    SET_TARGET_PROPERTIES(vigraimpex PROPERTIES VERSION ${SOVERSION}.${vigra_version}
+                          SOVERSION ${SOVERSION}
+                          CXX_STANDARD 11)
 ENDIF()
 
 IF(JPEG_FOUND)


### PR DESCRIPTION
I can not build current vigra HEAD due to errors like:
```
[1/4] /usr/bin/c++  -DHasJPEG -DHasPNG -DHasTIFF -DHasZLIB -DUSE_BOOST_THREAD -Dvigraimpex_EXPORTS -I/tmp/GIT-vigra/include -isystem /data/Debug/Shared/include -fPIC -ggdb3 -fno-omit-frame-pointer -O1 -m64 -march=nehalem -mtune=haswell  -DDEBUG -g -fPIC -MD -MT src/impex/CMakeFiles/vigraimpex.dir/sifImport.cxx.o -MF src/impex/CMakeFiles/vigraimpex.dir/sifImport.cxx.o.d -o src/impex/CMakeFiles/vigraimpex.dir/sifImport.cxx.o -c /tmp/GIT-vigra/src/impex/sifImport.cxx
FAILED: src/impex/CMakeFiles/vigraimpex.dir/sifImport.cxx.o 
/usr/bin/c++  -DHasJPEG -DHasPNG -DHasTIFF -DHasZLIB -DUSE_BOOST_THREAD -Dvigraimpex_EXPORTS -I/tmp/GIT-vigra/include -isystem /data/Debug/Shared/include -fPIC -ggdb3 -fno-omit-frame-pointer -O1 -m64 -march=nehalem -mtune=haswell  -DDEBUG -g -fPIC -MD -MT src/impex/CMakeFiles/vigraimpex.dir/sifImport.cxx.o -MF src/impex/CMakeFiles/vigraimpex.dir/sifImport.cxx.o.d -o src/impex/CMakeFiles/vigraimpex.dir/sifImport.cxx.o -c /tmp/GIT-vigra/src/impex/sifImport.cxx
In file included from /usr/include/c++/5/tuple:35:0,
                 from /tmp/GIT-vigra/include/vigra/utilities.hxx:49,
                 from /tmp/GIT-vigra/include/vigra/basicimage.hxx:41,
                 from /tmp/GIT-vigra/include/vigra/multi_array.hxx:45,
                 from /tmp/GIT-vigra/include/vigra/sifImport.hxx:61,
                 from /tmp/GIT-vigra/src/impex/sifImport.cxx:58:
/usr/include/c++/5/bits/c++0x_warning.h:32:2: error: #error This file requires compiler and library support for the ISO C++ 2011 standard. This support must be enabled with the -std=c++11 or -std=gnu++11 compiler options.
 #error This file requires compiler and library support \
  ^
In file included from /tmp/GIT-vigra/include/vigra/basicimage.hxx:41:0,
                 from /tmp/GIT-vigra/include/vigra/multi_array.hxx:45,
                 from /tmp/GIT-vigra/include/vigra/sifImport.hxx:61,
                 from /tmp/GIT-vigra/src/impex/sifImport.cxx:58:
/tmp/GIT-vigra/include/vigra/utilities.hxx:231:29: error: expected ‘,’ or ‘...’ before ‘&&’ token
         void operator()(TPL && t, FUNCTOR && f) const
                             ^
```
I am under the impression that vigra does currently not use c++11. Attached patch enables it for the vigraimpex library.