### PR TITLE
Receive `const char *` from `PyUnicode_AsUTF8`

### DIFF
--- a/vigranumpy/src/core/vigranumpycore.cxx
+++ b/vigranumpy/src/core/vigranumpycore.cxx
@@ -61,7 +61,7 @@ UInt32 pychecksum(python::str const & s)
 	return checksum(data, size);
 #else
 	Py_ssize_t size = 0;
-	char * data = PyUnicode_AsUTF8AndSize(s.ptr(), &size);
+	const char * data = PyUnicode_AsUTF8AndSize(s.ptr(), &size);
 	return checksum(data, size);
 #endif
 }


### PR DESCRIPTION
In Python 3.7, `PyUnicode_AsUTF8` was changed to return a `const char *` instead of a `char *`. This broke VIGRA as we were accepting a `char *` in this case instead. Fortunately we do not need it to be mutable for our use case. So just type the variable storing the result from `PyUnicode_AsUTF8` as a `const char *`. Should still work on older Python 3 versions that return `char *` as well.

xref: https://github.com/ukoethe/vigra/issues/450
ref: https://bugs.python.org/issue28769