### PR TITLE
Fix C++ version detection for WebAssembly.

### DIFF
--- a/config/output_cplusplus_version.cxx
+++ b/config/output_cplusplus_version.cxx
@@ -6,14 +6,14 @@ int main() {
         // This is a workaround for a gcc bug:
         // http://stackoverflow.com/questions/7530047/gnu-c-macro-cplusplus-standard-conform
 #ifdef __GXX_EXPERIMENTAL_CXX0X__
-        std::cout << 201103;
+        std::cout << 201103 << std::endl;
 #else
-        std::cout << 199711;
+        std::cout << 199711 << std::endl;
 #endif
     }
     else
     {
-        std::cout << __cplusplus;
+        std::cout << __cplusplus << std::endl;
     }
     return 0;
 }


### PR DESCRIPTION
The Emscripten compiler (`em++`) will refuse to output the results of the buffer unless they are flushed explicitly, or implicitly with the `std::endl`. This will result in the C++ version being detected as being the literal string:

> `stdio streams had content in them that was not flushed. you should set EXIT_RUNTIME to 1 (see the FAQ), or make sure to emit a newline when you printf etc.`