### PR TITLE
use tuples for numpy indexing

### DIFF
--- a/vigranumpy/lib/arraytypes.py
+++ b/vigranumpy/lib/arraytypes.py
@@ -1119,7 +1119,7 @@ class VigraArray(numpy.ndarray):
                 if slicing[k] == 0 and self.shape[k] != 1:
                     raise RuntimeError("VigraArray.withAxes(): cannot drop non-singleton axis '%s'." % self.axistags[k].key)
             permutation = AxisTags(axisinfo).permutationFromNumpyOrder()
-            res = self[slicing].transposeToNumpyOrder().transpose(permutation)
+            res = self[tuple(slicing)].transposeToNumpyOrder().transpose(permutation)
         else:
             res = self.transposeToOrder(kw.get('order'))
             if kw.get('noChannels'):
@@ -1142,7 +1142,7 @@ class VigraArray(numpy.ndarray):
             except:
                 raise RuntimeError("VigraArray.view5D(): array contains unsuitable axis key '%s'." % tag.key)
         index = [Ellipsis] + [newaxis(eval('AxisInfo.' + k)) for k in stdTags]
-        return self[index].transposeToOrder(order)
+        return self[tuple(index)].transposeToOrder(order)
 
     def permutationToOrder(self, order):
         '''Create the permutation that would transpose this array into
@@ -1265,7 +1265,7 @@ class VigraArray(numpy.ndarray):
             if not isinstance(index, collections.Iterable):
                 raise
             #create temporary index without AxisInfor in order to use np.ndarray.__getitem__
-            tmpindex = [None if isinstance(x, AxisInfo) else x for x in index]
+            tmpindex = tuple(None if isinstance(x, AxisInfo) else x for x in index)
             res = numpy.ndarray.__getitem__(self, tmpindex)
         if res is not self and hasattr(res, 'axistags'):
             if res.base is self or res.base is self.base:


### PR DESCRIPTION
Hi @ukoethe,

maybe it's the social isolation but warnings in ilastik started bothering me a lot. Some of them go back to vigra and could be fixed with the patch of this PR. While the changes here are not critical right now (I couldn't find a timeline about this deprecation) it cannot hurt to be prepared.

`numpy` currently warns with the following warning when not using tuples for
indexing:

```
vigranumpy/vigra/arraytypes.py:1263: FutureWarning: Using a non-tuple sequence
for multidimensional indexing is deprecated; use `arr[tuple(seq)]` instead of `arr[seq]`.
In the future this will be interpreted as an array index, `arr[np.array(seq)]`, which will
result either in an error or a different result.
```

fixed by simply converting the index to a tuple in relevant places.

fixes #474