### PR TITLE
Fix typo in installation instructions

### DIFF
--- a/docsrc/installation.dxx
+++ b/docsrc/installation.dxx
@@ -54,7 +54,7 @@
          <DD> build VIGRA Python bindings (default: 1). Pass -DWITH_VIGRANUMPY=0 to suppress 
          vigranumpy.
     <DT> -DWITH_HDF5=1
-         <DD> build VIGRA with HDF5 support (default: 1). Pass -DDWITH_HDF5=0 to compile without HDF5.
+         <DD> build VIGRA with HDF5 support (default: 1). Pass -DWITH_HDF5=0 to compile without HDF5.
     <DT> -DLIB_SUFFIX=64
          <DD> define suffix of lib directory name (default: empty string, i.e. no suffix). Use 
          -DLIB_SUFFIX=64 when you want to install libraries in $CMAKE_INSTALL_PREFIX/lib64.


### PR DESCRIPTION
The installation instructions say that one may pass `-DDWITH_HDF5=0` in order to compile without HDF5, but this gives the following warning and does not disable compiling HDF5:

```
CMake Warning:
  Manually-specified variables were not used by the project:

    DWITH_HDF5
```

The actual option must be `-DWITH_HDF5=0`.