### PR TITLE
build: update cmake from 2.6 to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.10)
 
 ##################################################
 #

--- a/config/VigraDetectThreading.cmake
+++ b/config/VigraDetectThreading.cmake
@@ -3,8 +3,6 @@
 # Source modules should use VIGRA_CONFIGURE_THREADING() from VigraConfigureThreading.cmake to set includes/preprocessor definitions.
 #
 
-cmake_minimum_required(VERSION 2.8)
-
 get_property(THREADING_IMPLEMENTATION GLOBAL PROPERTY THREADING_IMPLEMENTATION)
 if(THREADING_IMPLEMENTATION)
     message(FATAL_ERROR "VigraDetectThreading.cmake should be included exactly once, from the root CMakeLists.txt file.  There should be no need to include it more than once.")


### PR DESCRIPTION
CMake 2.6 is really ancient and deprecated: newer CMake will stop
supporting it. Updating also allows to use modern CMake techniques.

This also makes it easier for other CMake projects to use VIGRA
(I stumbled on this while trying to build Hugin).

To give an idea, CMake is currently at 3.19. CMake 3.10 is what is
shipped with Ubuntu 18.04, which has been released in April 2018.

If we wanted to be more conservative, we could maybe use the CMake
version shipped with Ubuntu 16.04, but 16.04 itself will be end of life
in April 2021...

Tested on macOS 10.15 Catalina.