### PR TITLE
Add compatibility for HDF5 1.12

### DIFF
--- a/src/impex/hdf5impex.cxx
+++ b/src/impex/hdf5impex.cxx
@@ -190,7 +190,11 @@ H5O_type_t HDF5_get_type(hid_t loc_id, const char* name)
 {
     // get information about object
     H5O_info_t infobuf;
+#if H5Oget_info_by_name_vers >= 3
+    H5Oget_info_by_name(loc_id, name, &infobuf, H5O_INFO_BASIC, H5P_DEFAULT);
+#else
     H5Oget_info_by_name(loc_id, name, &infobuf, H5P_DEFAULT);
+#endif
     return infobuf.type;
 }
 


### PR DESCRIPTION
Closes https://github.com/ukoethe/vigra/issues/476

See builds: https://github.com/conda-forge/vigra-feedstock/pull/77

The relevant code in `H5version.h` is:

```c
#if !defined(H5Oget_info_by_name_vers) || H5Oget_info_by_name_vers == 3
  #ifndef H5Oget_info_by_name_vers
    #define H5Oget_info_by_name_vers 3
  #endif /* H5Oget_info_by_name_vers */
  #define H5Oget_info_by_name H5Oget_info_by_name3
#elif H5Oget_info_by_name_vers == 2
  #define H5Oget_info_by_name H5Oget_info_by_name2
#elif H5Oget_info_by_name_vers == 1
  #define H5Oget_info_by_name H5Oget_info_by_name1
#else /* H5Oget_info_by_name_vers */
  #error "H5Oget_info_by_name_vers set to invalid value"
#endif /* H5Oget_info_by_name_vers */
```