### PR TITLE
Use UTF-8 in two files

### DIFF
--- a/include/vigra/matrix.hxx
+++ b/include/vigra/matrix.hxx
@@ -2951,7 +2951,7 @@ prepareColumns(MultiArrayView<2, T, C1> const & A, MultiArrayView<2, T, C2> & re
                     MultiArrayView<2, T, C2> & res,
                     MultiArrayView<2, T, C3> & offset,
                     MultiArrayView<2, T, C4> & scaling,
-                    DataPreparationGoals goals = ZeroMean | UnitVariance)´;
+                    DataPreparationGoals goals = ZeroMean | UnitVariance);
     } }
     \endcode
 

--- a/include/vigra/wigner-matrix.hxx
+++ b/include/vigra/wigner-matrix.hxx
@@ -52,7 +52,7 @@ namespace vigra {
     /**
      *  \class WignerMatrix 
      *  \brief computation of Wigner D matrix + rotation functions 
-     *         in SH,VH and R³
+     *         in SH,VH and RÂ³
      *
      * All rotations in Euler zyz' convention   
      *


### PR DESCRIPTION
Orignally from

Description: Re-encode two files from ISO-8859-1 to UTF-8
 Fixes a documentation generation error.
Author: Andreas Metzler <ametzler@debian.org>
Origin: vendor
Bug-Debian: https://bugs.debian.org/980630
Forwarded: no
Last-Update: 2021-01-31