### PR TITLE
for C++20 (and beyond), don't refer to std::unary_negate or std::binary_negate 

### DIFF
--- a/include/vigra/functortraits.hxx
+++ b/include/vigra/functortraits.hxx
@@ -190,11 +190,15 @@ VIGRA_DEFINE_STL_FUNCTOR(std::greater_equal, VigraFalseType, VigraTrueType)
 VIGRA_DEFINE_STL_FUNCTOR(std::less_equal, VigraFalseType, VigraTrueType)
 VIGRA_DEFINE_STL_FUNCTOR(std::logical_and, VigraFalseType, VigraTrueType)
 VIGRA_DEFINE_STL_FUNCTOR(std::logical_or, VigraFalseType, VigraTrueType)
-VIGRA_DEFINE_STL_FUNCTOR(std::binary_negate, VigraFalseType, VigraTrueType)
 
 VIGRA_DEFINE_STL_FUNCTOR(std::negate, VigraTrueType, VigraFalseType)
 VIGRA_DEFINE_STL_FUNCTOR(std::logical_not, VigraTrueType, VigraFalseType)
+
+#if !( (__cplusplus >= 202002L) || (defined(_MSC_VER) && _MSVC_LANG >= 202002L) )
+VIGRA_DEFINE_STL_FUNCTOR(std::binary_negate, VigraFalseType, VigraTrueType)
 VIGRA_DEFINE_STL_FUNCTOR(std::unary_negate, VigraTrueType, VigraFalseType)
+#endif
+
 #undef VIGRA_DEFINE_STL_FUNCTOR
 
 template <class R>


### PR DESCRIPTION
Running tests for #534