### PR TITLE
random_shuffle removed in c++17

### DIFF
--- a/include/vigra/random_forest/rf_algorithm.hxx
+++ b/include/vigra/random_forest/rf_algorithm.hxx
@@ -35,6 +35,7 @@
 #ifndef VIGRA_RF_ALGORITHM_HXX
 #define VIGRA_RF_ALGORITHM_HXX
 #include <vector>
+#include <random>
 #include "splices.hxx"
 #include <queue>
 #include <fstream>
@@ -1150,8 +1151,10 @@ class ClusterImportanceVisitor : public visitors::VisitorBase
             ArrayVector<int> cts(2, 0);
             ArrayVector<Int32> indices(pr.features().shape(0));
             for(int ii = 0; ii < pr.features().shape(0); ++ii)
-               indices.push_back(ii); 
-            std::random_shuffle(indices.begin(), indices.end());
+               indices.push_back(ii); ;
+            std::random_device rd;
+            std::mt19937 g(rd());
+            std::shuffle(indices.begin(), indices.end(), g);
             for(int ii = 0; ii < rf.ext_param_.row_count_; ++ii)
             {
                 if(!sm.is_used()[indices[ii]] && cts[pr.response()(indices[ii], 0)] < 3000)

--- a/include/vigra/random_forest/rf_visitors.hxx
+++ b/include/vigra/random_forest/rf_visitors.hxx
@@ -41,6 +41,7 @@
 #include <vigra/windows.h>
 #include <iostream>
 #include <iomanip>
+#include <random>
 
 #include <vigra/metaprogramming.hxx>
 #include <vigra/multi_pointoperators.hxx>
@@ -920,7 +921,9 @@ class OOB_Error : public VisitorBase
         {
             ArrayVector<int> oob_indices;
             ArrayVector<int> cts(class_count, 0);
-            std::random_shuffle(indices.begin(), indices.end());
+            std::random_device rd;
+            std::mt19937 g(rd());
+            std::shuffle(indices.begin(), indices.end(), g);
             for(int ii = 0; ii < rf.ext_param_.row_count_; ++ii)
             {
                 if(!sm.is_used()[indices[ii]] && cts[pr.response()(indices[ii], 0)] < 40000)


### PR DESCRIPTION
clang seems to have actually implemented removal recently :)

example for a failed build on conda due to `random_shuffle` being removed...