### PR TITLE
Use importlib.reload instead of imp.reload

### DIFF
--- a/vigranumpy/lib/axistags.py
+++ b/vigranumpy/lib/axistags.py
@@ -241,7 +241,7 @@ def benchmark(expression):
        when getitem returns a value, the slowdown is about 3 (due to Python calls)
     '''
     import timeit, axistags
-    from imp import reload
+    from importlib import reload
     reload(axistags)
     repetitions = 100000
     t1 = timeit.Timer(expression,


### PR DESCRIPTION
The imp module has been deprecated since Python 3.4 and is removed in Python 3.12.
Replace its use with its replacement in the importlib module.