### PR TITLE
fix typo in multi_iterator_coupled

### DIFF
--- a/include/vigra/multi_iterator_coupled.hxx
+++ b/include/vigra/multi_iterator_coupled.hxx
@@ -490,7 +490,7 @@ class CoupledScanOrderIterator<N, HANDLES, 0>
     CoupledScanOrderIterator operator--(int)
     {
         CoupledScanOrderIterator res(*this);
-        std::advance(this, -1);
+        std::advance(*this, -1);
         return res;
     }
 

--- a/include/vigra/multi_iterator_coupled.hxx
+++ b/include/vigra/multi_iterator_coupled.hxx
@@ -490,7 +490,7 @@ class CoupledScanOrderIterator<N, HANDLES, 0>
     CoupledScanOrderIterator operator--(int)
     {
         CoupledScanOrderIterator res(*this);
-        --this;
+        std::advance(this, -1);
         return res;
     }
 


### PR DESCRIPTION
In multi_iterator_coupled.hxx clang19 emits an error "expression is not assignable" for the expression "--this".  This is clearly a typo, the intended expression was "--*this".  However a more modern version is to use std::advance.

Fixes #591 .