### PR TITLE
Use posix shell instead of bash for tests

### DIFF
--- a/config/run_test.sh.in
+++ b/config/run_test.sh.in
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/bin/sh
 PATH=@EXTRA_PATH@$PATH && cd @CMAKE_CURRENT_BINARY_DIR@ && (@VIGRA_TEST_EXECUTABLE@ || { touch testsuccess.cxx; exit 1; } )


### PR DESCRIPTION
The script so simple that it should be portable to all used shells. Avoids bash as an extra build dependency

Edit: CI failure doesn't seem related