### PR TITLE
Fix macos runner on CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,7 +26,16 @@ jobs:
         py310:
           PYTHON_VERSION: 3.10
     steps:
+      # Conda was removed from macos vmImages 13 and 14
       - script: |
+          curl -fsSLo Miniforge3.sh "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-$(uname -m).sh"
+          bash Miniforge3.sh -b -p "${HOME}/conda"
+          rm Miniforge3.sh
+          source "${HOME}/conda/etc/profile.d/conda.sh"
+        displayName: Install miniforge in runner
+      - bash: echo "##vso[task.prependpath]~/conda/bin"
+        displayName: Add conda to PATH
+      - bash: |
           sudo xcode-select -s /Applications/Xcode_13.2.1.app
           bash ci/build_unix.sh
   - job: Windows

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,10 +28,12 @@ jobs:
     steps:
       # Conda was removed from macos vmImages 13 and 14
       - script: |
+          CONDA=~/conda
           curl -fsSLo Miniforge3.sh "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-$(uname -m).sh"
-          bash Miniforge3.sh -b -p "${HOME}/conda"
+          bash Miniforge3.sh -b -p "${CONDA}"
           rm Miniforge3.sh
-          source "${HOME}/conda/etc/profile.d/conda.sh"
+          source "${CONDA}/etc/profile.d/conda.sh"
+          echo "##vso[task.setvariable variable=CONDA]$CONDA";
         displayName: Install miniforge in runner
       - bash: echo "##vso[task.prependpath]~/conda/bin"
         displayName: Add conda to PATH


### PR DESCRIPTION
The latest runners for MacOs on Azuere don't come with conda preinstalled anymore. It is recommended to manually install: https://github.com/actions/runner-images/issues/9262#issuecomment-1918858684