### PR TITLE
modernise for c++20

### DIFF
--- a/include/vigra/accumulator.hxx
+++ b/include/vigra/accumulator.hxx
@@ -2227,7 +2227,7 @@ class DynamicAccumulatorChain
                                          normalizeString(tag), acc_detail::ActivateTag_Visitor());
     }
 
-    bool isActiveImpl(std::string tag, acc_detail::TagIsActive_Visitor & v) const
+    bool isActiveImpl(std::string tag, const acc_detail::TagIsActive_Visitor & v) const
     {
         return acc_detail::ApplyVisitorToTag<AccumulatorTags>::exec(*this, normalizeString(tag), v);
     }

--- a/include/vigra/basicimage.hxx
+++ b/include/vigra/basicimage.hxx
@@ -582,7 +582,6 @@ class BasicImage
     typedef Alloc allocator_type;
 
     typedef Alloc Allocator;
-
     typedef typename std::allocator_traits<Alloc>::template rebind_alloc<PIXELTYPE*> LineAllocator;
 
         /** construct image of size 0x0

--- a/include/vigra/basicimage.hxx
+++ b/include/vigra/basicimage.hxx
@@ -582,7 +582,8 @@ class BasicImage
     typedef Alloc allocator_type;
 
     typedef Alloc Allocator;
-    typedef typename Alloc::template rebind<PIXELTYPE *>::other LineAllocator;
+
+    typedef typename std::allocator_traits<Alloc>::template rebind_alloc<PIXELTYPE*> LineAllocator;
 
         /** construct image of size 0x0
         */

--- a/include/vigra/blockwise_labeling.hxx
+++ b/include/vigra/blockwise_labeling.hxx
@@ -280,7 +280,7 @@ blockwiseLabeling(DataBlocksIterator data_blocks_begin, DataBlocksIterator data_
 
 template <class LabelBlocksIterator, class MappingIterator>
 void toGlobalLabels(LabelBlocksIterator label_blocks_begin, LabelBlocksIterator label_blocks_end,
-                    MappingIterator mapping_begin, MappingIterator mapping_end)
+                    MappingIterator mapping_begin, [[maybe_unused]] MappingIterator mapping_end)
 {
     typedef typename LabelBlocksIterator::value_type LabelBlock;
     for( ; label_blocks_begin != label_blocks_end; ++label_blocks_begin, ++mapping_begin)

--- a/include/vigra/gaborfilter.hxx
+++ b/include/vigra/gaborfilter.hxx
@@ -46,9 +46,10 @@
 #include "utilities.hxx"
 #include "multi_shape.hxx"
 
-#include <functional>
-#include <vector>
 #include <cmath>
+#include <functional>
+#include <memory>
+#include <vector>
 
 namespace vigra {
 
@@ -316,7 +317,7 @@ inline double angularGaborSigma(int directionCount, double centerFrequency)
     Namespace: vigra
 */
 template <class ImageType,
-          class Alloc = typename ImageType::allocator_type::template rebind<ImageType>::other >
+          class Alloc = typename std::allocator_traits<typename ImageType::allocator_type>::template rebind_alloc<ImageType> >
 class GaborFilterFamily
 : public ImageArray<ImageType, Alloc>
 {

--- a/include/vigra/imagecontainer.hxx
+++ b/include/vigra/imagecontainer.hxx
@@ -39,6 +39,7 @@
 #include "utilities.hxx"
 #include "array_vector.hxx"
 #include "copyimage.hxx"
+#include <memory>
 
 namespace vigra {
 
@@ -68,7 +69,7 @@ namespace vigra {
     Namespace: vigra
 */
 template <class ImageType,
-      class Alloc = typename ImageType::allocator_type::template rebind<ImageType>::other >
+      class Alloc = typename std::allocator_traits<typename ImageType::allocator_type>::template rebind_alloc<ImageType> >
 class ImageArray
 {
     Size2D imageSize_;
@@ -464,7 +465,7 @@ public:
     Namespace: vigra
 */
 template <class ImageType,
-      class Alloc = typename ImageType::allocator_type::template rebind<ImageType>::other >
+      class Alloc = typename std::allocator_traits<typename ImageType::allocator_type>::template rebind_alloc<ImageType> >
 class ImagePyramid
 {
     int lowestLevel_, highestLevel_;

--- a/include/vigra/memory.hxx
+++ b/include/vigra/memory.hxx
@@ -182,8 +182,13 @@ template <class T, class Alloc>
 inline void
 destroy_dealloc_impl(T * p, std::size_t n, Alloc & alloc, VigraFalseType /* isPOD */)
 {
-    for (std::size_t i=0; i < n; ++i)
+    for (std::size_t i=0; i < n; ++i) {
+#if (__cplusplus >= 202002L) || (defined(_MSC_VER) && _MSVC_LANG >= 202002L)
+        std::destroy_at(p + i);
+#else
         alloc.destroy(p + i);
+#endif
+    }
     alloc.deallocate(p, n);
 }
 

--- a/include/vigra/memory.hxx
+++ b/include/vigra/memory.hxx
@@ -45,6 +45,8 @@
 #  include <memory>
 #endif
 
+#include <memory>
+
 #include <cstring>
 #include "metaprogramming.hxx"
 
@@ -131,13 +133,23 @@ alloc_initialize_n(std::size_t n, T const & initial, Alloc & alloc)
         std::size_t i=0;
         try
         {
-            for (; i < n; ++i)
-                alloc.construct(p+i, initial);
+            for (; i < n; ++i) {
+#if (__cplusplus >= 202002L) || (defined(_MSC_VER) && _MSVC_LANG >= 202002L)
+                std::construct_at(p+i, initial); // from c++20
+#else
+                alloc.construct(p+i, initial); // until c++20
+#endif
+            }
         }
         catch (...)
         {
-            for (std::size_t j=0; j < i; ++j)
-                alloc.destroy(p+j);
+            for (std::size_t j=0; j < i; ++j) {
+#if (__cplusplus >= 202002L) || (defined(_MSC_VER) && _MSVC_LANG >= 202002L)
+                std::destroy_at(p+j); // from c++20
+#else
+                alloc.destroy(p+j); // until c++20
+#endif
+            }
             alloc.deallocate(p, n);
             throw;
         }

--- a/include/vigra/memory.hxx
+++ b/include/vigra/memory.hxx
@@ -45,8 +45,6 @@
 #  include <memory>
 #endif
 
-#include <memory>
-
 #include <cstring>
 #include "metaprogramming.hxx"
 

--- a/include/vigra/random.hxx
+++ b/include/vigra/random.hxx
@@ -42,6 +42,7 @@
 #include "array_vector.hxx"
 
 #include <ctime>
+#include <cstdint>
 
     // includes to get the current process and thread IDs
     // to be used for automated seeding
@@ -133,7 +134,7 @@ void seed(RandomSeedTag, RandomState<EngineTag> & engine)
     seedData.push_back(static_cast<UInt32>(clock()));
     seedData.push_back(++globalCount);
 
-    std::size_t ptr((char*)&engine - (char*)0);
+    const uintptr_t ptr = reinterpret_cast<uintptr_t>(&engine);
     seedData.push_back(static_cast<UInt32>((ptr & 0xffffffff)));
     static const UInt32 shift = sizeof(ptr) > 4 ? 32 : 16;
     seedData.push_back(static_cast<UInt32>((ptr >> shift)));

--- a/include/vigra/random_access_set.hxx
+++ b/include/vigra/random_access_set.hxx
@@ -73,9 +73,9 @@ public:
    /// value comperator
    typedef Compare value_compare;
    /// acclocator
-   typedef Alloc  allocator_type;
+   typedef Alloc allocator_type;
    /// const reference type
-   typedef typename Alloc::const_reference const_reference;
+   typedef const Key& const_reference;
    /// iterator type
    typedef typename VectorType::iterator iterator;
    /// const iterator type
@@ -87,9 +87,9 @@ public:
    /// const pointer type
    typedef typename VectorType::const_pointer const_pointer;
    /// const reverse iterator
-   typedef typename VectorType::const_reverse_iterator  const_reverse_iterator;
+   typedef typename VectorType::const_reverse_iterator const_reverse_iterator;
 
-   // memeber functions:
+   // member functions:
    // constructor
    RandomAccessSet(const size_t, const Compare& compare=Compare(), const Alloc& alloc=Alloc());
    RandomAccessSet(const Compare& compare=Compare(), const Alloc& alloc=Alloc());

--- a/include/vigra/random_forest/rf_earlystopping.hxx
+++ b/include/vigra/random_forest/rf_earlystopping.hxx
@@ -27,8 +27,8 @@ class StopBase
 {
 protected:
     ProblemSpec<> ext_param_;
-    int tree_count_ ;
-    bool is_weighted_;
+    int tree_count_ = 0;
+    bool is_weighted_ = false;
 
 public:
     template<class T>
@@ -424,7 +424,7 @@ public:
     int max_depth_;
     int min_size_;
 
-    int max_depth_reached; //for debug maximum reached depth
+    int max_depth_reached = 0; //for debug maximum reached depth
 
     DepthAndSizeStopping()
         : max_depth_(NumericTraits<int>::max()), min_size_(0)

--- a/include/vigra/splineimageview.hxx
+++ b/include/vigra/splineimageview.hxx
@@ -120,7 +120,7 @@ class SplineImageView
 
         /** The order of the spline used.
         */
-    enum StaticOrder { order = ORDER };
+    constexpr static int order = ORDER;
 
         /** The type of the internal image holding the spline coefficients.
         */
@@ -132,7 +132,8 @@ class SplineImageView
     typedef typename InternalTraverser::column_iterator InternalColumnIterator;
     typedef BSpline<ORDER, double> Spline;
 
-    enum { ksize_ = ORDER + 1, kcenter_ = ORDER / 2 };
+    constexpr static int ksize_ = ORDER + 1;
+    constexpr static int kcenter_ = ORDER / 2;
 
   public:
 

--- a/src/impex/exr.cxx
+++ b/src/impex/exr.cxx
@@ -55,7 +55,6 @@
 using namespace Imf;
 using namespace Imath;
 
-
 namespace vigra {
 
     CodecDesc ExrCodecFactory::getCodecDesc() const

--- a/src/impex/exr.cxx
+++ b/src/impex/exr.cxx
@@ -55,6 +55,7 @@
 using namespace Imf;
 using namespace Imath;
 
+
 namespace vigra {
 
     CodecDesc ExrCodecFactory::getCodecDesc() const
@@ -379,7 +380,7 @@ namespace vigra {
         scanline++;
     }
 
-    void ExrEncoderImpl::setCompressionType( const std::string & comp, int quality){
+    void ExrEncoderImpl::setCompressionType( const std::string & comp, int /*quality*/ ){
        if (comp == "NONE")
            exrcomp = NO_COMPRESSION;
        else if (comp == "ZIP")

--- a/src/impex/lz4.c
+++ b/src/impex/lz4.c
@@ -370,7 +370,7 @@ typedef enum { full = 0, partial = 1 } earlyEnd_directive;
 **************************************/
 int LZ4_versionNumber (void) { return LZ4_VERSION_NUMBER; }
 int LZ4_compressBound(int isize)  { return LZ4_COMPRESSBOUND(isize); }
-int LZ4_sizeofState() { return LZ4_STREAMSIZE; }
+int LZ4_sizeofState(void) { return LZ4_STREAMSIZE; }
 
 
 
@@ -1471,7 +1471,7 @@ int LZ4_uncompress_unknownOutputSize (const char* source, char* dest, int isize,
 
 /* Obsolete Streaming functions */
 
-int LZ4_sizeofStreamState() { return LZ4_STREAMSIZE; }
+int LZ4_sizeofStreamState(void) { return LZ4_STREAMSIZE; }
 
 static void LZ4_init(LZ4_stream_t_internal* lz4ds, BYTE* base)
 {


### PR DESCRIPTION
Fix all compile time errors and warnings for clang++-19  / c++-20, while also compiling as c++-11/14/17 without errors/warnings.  g++-14 compiles as c++-11/14/17/20 without errors but several warnings (that existed previously). 

The fixed errors are mainly removed member types of std::allocator.