### PR TITLE
random.hxx: fix macOS version macros

### DIFF
--- a/include/vigra/random.hxx
+++ b/include/vigra/random.hxx
@@ -153,11 +153,11 @@ void seed(RandomSeedTag, RandomState<EngineTag> & engine)
 
 #ifdef __APPLE__
     seedData.push_back(static_cast<UInt32>(getpid()));
-  #if __MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_12
+  #if MAC_OS_X_VERSION_MAX_ALLOWED >= 101200
     uint64_t tid64;
     pthread_threadid_np(NULL, &tid64);
     seedData.push_back(static_cast<UInt32>(tid64));
-  #elif defined(SYS_thread_selfid) && (__MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_6)
+  #elif defined(SYS_thread_selfid) && (MAC_OS_X_VERSION_MAX_ALLOWED >= 1060)
     // SYS_thread_selfid was introduced in MacOS 10.6
     seedData.push_back(static_cast<UInt32>(syscall(SYS_thread_selfid)));
   #elif defined(SYS_gettid)


### PR DESCRIPTION
Current macros have a wrong effect, since neither `__MAC_OS_X_VERSION_MAX_ALLOWED` nor `MAC_OS_X_VERSION_10_12` are defined on earlier systems. `AvailabilityMacros` uses macros without leading underscores. `MAC_OS_X_VERSION_10_12` is defined on 10.12+.
Fix them, so that it actually works as intended.