### PR TITLE
Fix windows CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,7 +44,7 @@ jobs:
           bash ci/build_unix.sh
   - job: Windows
     pool:
-      vmImage: windows-2019
+      vmImage: windows-2022
     strategy:
       matrix:
         windows_py310:

--- a/ci/build_unix.sh
+++ b/ci/build_unix.sh
@@ -2,11 +2,11 @@ set -ex
 
 PYTHON_VERSION="${PYTHON_VERSION:-3.10}"
 
-conda config --add channels conda-forge
-conda config --remove channels defaults || true
 conda config --show
 conda create \
     --quiet --yes \
+    --override-channels \
+    -c conda-forge -c nodefaults \
     --name vigra \
     python=${PYTHON_VERSION} pytest c-compiler cxx-compiler \
     zlib libjpeg-turbo libpng libtiff hdf5 fftw \

--- a/ci/build_unix.sh
+++ b/ci/build_unix.sh
@@ -10,7 +10,7 @@ conda create \
     --name vigra \
     python=${PYTHON_VERSION} pytest c-compiler cxx-compiler \
     zlib libjpeg-turbo libpng libtiff hdf5 fftw \
-    boost boost-cpp numpy h5py sphinx \
+    libboost-python libboost-python-devel numpy h5py sphinx \
     openexr lemon cmake make ruff
 
 if [[ `uname` == 'Darwin' ]]; then

--- a/ci/build_windows.bat
+++ b/ci/build_windows.bat
@@ -2,14 +2,13 @@
 call conda info
 if errorlevel 1 exit 1
 
-call conda config --add channels conda-forge
-if errorlevel 1 exit 1
-call conda config --remove channels defaults || true
-if errorlevel 1 exit 1
 call conda config --show
 if errorlevel 1 exit 1
 
 call conda create ^
+    --override-channels ^
+    -c conda-forge ^
+    -c nodefaults ^
     --quiet --yes ^
     --name vigra ^
     python=%PYTHON_VERSION% pytest c-compiler cxx-compiler ^

--- a/ci/build_windows.bat
+++ b/ci/build_windows.bat
@@ -13,7 +13,7 @@ call conda create ^
     --name vigra ^
     python=%PYTHON_VERSION% pytest c-compiler cxx-compiler ^
     zlib libjpeg-turbo libpng libtiff hdf5 fftw cmake ninja ^
-    boost boost-cpp numpy h5py sphinx ^
+    libboost-python libboost-python-devel numpy h5py sphinx ^
     openexr lemon
 
 if errorlevel 1 exit 1


### PR DESCRIPTION
windows ci is currently failing because of the defaults channel being included there, and apparently requiring some sort of interaction to use.

Summary:
* updated windows ci image to `windows-2022` (`windows-2019` is deprecated)
* removed channel changes via `conda config` from ci (seems unreliable), both builds now use `--override channels -c conda-forge -c nodefaults`. That way, the ci scripts can also be used on local machines.
* use updated boost packages `libboost-python` and `libboost-python-devel`

edit: looks like mangling the condarc on the windows runner did not have the desired effect, the defaults channel was still in place. Switched to `--override-channels -c conda-forge -c nodefaults` in the one conda call in `build-windows.bat`. Added value: one can more or less call `build-windows.bat` on a different machine (no side effect to machine configuration).

note: squash and merge